### PR TITLE
fix for python ctypes to match C functions

### DIFF
--- a/mitielib/mitie.py
+++ b/mitielib/mitie.py
@@ -46,7 +46,7 @@ _f.mitie_load_entire_file.argtypes = ctypes.c_char_p,
 _f.mitie_ner_get_detection_position.restype = ctypes.c_ulong
 _f.mitie_ner_get_detection_position.argtypes = ctypes.c_void_p, ctypes.c_ulong
 
-_f.mitie_ner_get_detection_length.restype = ctypes.c_void_p
+_f.mitie_ner_get_detection_length.restype = ctypes.c_ulong
 _f.mitie_ner_get_detection_length.argtypes = ctypes.c_void_p, ctypes.c_ulong
 
 _f.mitie_ner_get_detection_tag.restype = ctypes.c_ulong


### PR DESCRIPTION
changed from `c_void_p` to `c_ulong`. Python was returning `None` when the result was the first item, where it should have been `0`

this also matches the C definitions

``` C
unsigned long mitie_ner_get_detection_length  ( ... )
unsigned long mitie_ner_get_detection_position ( ... )
```
