### PR TITLE
Separate model from extractor to reduce the size

### DIFF
--- a/examples/java/TrainSeparateNerExample.java
+++ b/examples/java/TrainSeparateNerExample.java
@@ -1,0 +1,122 @@
+import edu.mit.ll.mitie.*;
+
+/**
+ * Created by wihoho on 26/12/15.
+ */
+public class TrainSeparateNerExample {
+    public static void main(String[] args) {
+        // train models using the separation API
+        StringVector stringVector = new StringVector();
+        stringVector.add("My");
+        stringVector.add("name");
+        stringVector.add("is");
+        stringVector.add("Davis");
+        stringVector.add("King");
+        stringVector.add("and");
+        stringVector.add("I");
+        stringVector.add("work");
+        stringVector.add("for");
+        stringVector.add("MIT");
+        stringVector.add(".");
+
+        // Now that we have the tokens stored, we add the entity annotations.  The first
+        // annotation indicates that the token at index 3 and consisting of 2 tokens is a
+        // person.  I.e. "Davis King" is a person name.  Note that you can use any strings
+        // as the labels.  Here we use "person" and "org" but you could use any labels you
+        // like.
+        NerTrainingInstance nerTrainingInstance = new NerTrainingInstance(stringVector);
+        nerTrainingInstance.addEntity(3, 2, "person");
+        nerTrainingInstance.addEntity(9, 1, "org");
+
+        StringVector stringVector12 = new StringVector();
+        stringVector12.add("The");
+        stringVector12.add("other");
+        stringVector12.add("day");
+        stringVector12.add("at");
+        stringVector12.add("work");
+        stringVector12.add("I");
+        stringVector12.add("saw");
+        stringVector12.add("Brian");
+        stringVector12.add("Smith");
+        stringVector12.add("from");
+        stringVector12.add("CMU");
+        stringVector12.add(".");
+
+        NerTrainingInstance nerTrainingInstance1 = new NerTrainingInstance(stringVector12);
+        nerTrainingInstance1.addEntity(7, 2, "person");
+        nerTrainingInstance1.addEntity(10, 1, "org");
+
+        // Now that we have some annotated example sentences we can create the object that does
+        // the actual training, the NerTrainer.  The constructor for this object takes a string
+        // that should contain the file name for a saved mitie::total_word_feature_extractor C++ object.
+        // The total_word_feature_extractor is MITIE's primary method for analyzing words and
+        // is created by the tool in the MITIE/tools/wordrep folder.  The wordrep tool analyzes
+        // a large document corpus, learns important word statistics, and then outputs a
+        // total_word_feature_extractor that is knowledgeable about a particular language (e.g.
+        // English).  MITIE comes with a total_word_feature_extractor for English so that is
+        // what we use here.  But if you need to make your own you do so using a command line
+        // statement like:
+        //    wordrep -e a_folder_containing_only_text_files
+        // and wordrep will create a total_word_feature_extractor.dat based on the supplied
+        // text files.  Note that wordrep can take a long time to run or require a lot of RAM
+        // if a large text dataset is given.  So use a powerful machine and be patient.
+        NerTrainer nerTrainer = new NerTrainer("../../MITIE-models/english/total_word_feature_extractor.dat");
+        // Don't forget to add the training data.  Here we have only two examples, but for real
+        // uses you need to have thousands.
+        nerTrainer.add(nerTrainingInstance);
+        nerTrainer.add(nerTrainingInstance1);
+
+        // The trainer can take advantage of a multi-core CPU.  So set the number of threads
+        // equal to the number of processing cores for maximum training speed.
+        nerTrainer.setThreadNum(4);
+
+        // This function does the work of training.  Note that it can take a long time to run
+        // when using larger training datasets.  So be patient.  When it finishes it will
+        // save the resulting model into three different files including
+        // * test_ner_model.df.dat - decision function
+        // * test_ner_model.segmenter.dat - sequence_segmenter
+        // * test_ner_model.tns.dat - label and id mappings
+        nerTrainer.trainSeparateModels("test_ner_model");
+
+        // restore the model using the separated serialized files
+        NamedEntityExtractor ner = new NamedEntityExtractor(
+                "test_ner_model.df.dat",
+                "test_ner_model.segmenter.dat",
+                "test_ner_model.tns.dat",
+                "../../MITIE-models/english/total_word_feature_extractor.dat"
+        );
+
+        // Finally, lets test out our new model on an example sentence
+        StringVector testStringVector = new StringVector();
+        testStringVector.add("I");
+        testStringVector.add("met");
+        testStringVector.add("with");
+        testStringVector.add("John");
+        testStringVector.add("Becker");
+        testStringVector.add("at");
+        testStringVector.add("HBU");
+        testStringVector.add(".");
+
+        System.out.println("Tags output by this NER model are: ");
+        StringVector possibleTags = ner.getPossibleNerTags();
+        for (int i = 0; i < possibleTags.size(); ++i)
+            System.out.println(possibleTags.get(i));
+
+        // Now ask MITIE to find all the named entities in the file we just loaded.
+        EntityMentionVector entities = ner.extractEntities(testStringVector);
+        System.out.println("Number of entities found: " + entities.size());
+
+        // Now print out all the named entities and their tags
+        for (int i = 0; i < entities.size(); ++i)
+        {
+            EntityMention entity = entities.get(i);
+            String tag = possibleTags.get(entity.getTag());
+            Double score = entity.getScore();
+            String scoreStr = String.format("%1$,.3f",score);
+            System.out.print("   Score: " + scoreStr + ": " + tag + ":");
+            NerExample.printEntity(testStringVector, entity);
+        }
+
+
+    }
+}

--- a/examples/java/TrainSeparateNerExample.java
+++ b/examples/java/TrainSeparateNerExample.java
@@ -72,17 +72,12 @@ public class TrainSeparateNerExample {
 
         // This function does the work of training.  Note that it can take a long time to run
         // when using larger training datasets.  So be patient.  When it finishes it will
-        // save the resulting model into three different files including
-        // * test_ner_model.df.dat - decision function
-        // * test_ner_model.segmenter.dat - sequence_segmenter
-        // * test_ner_model.tns.dat - label and id mappings
-        nerTrainer.trainSeparateModels("test_ner_model");
+        // save the resulting pure model
+        nerTrainer.trainSeparateModels("pure_ner_model.dat");
 
-        // restore the model using the separated serialized files
+        // restore the model using the pure model and extractor
         NamedEntityExtractor ner = new NamedEntityExtractor(
-                "test_ner_model.df.dat",
-                "test_ner_model.segmenter.dat",
-                "test_ner_model.tns.dat",
+                "pure_ner_model.dat",
                 "../../MITIE-models/english/total_word_feature_extractor.dat"
         );
 
@@ -116,7 +111,5 @@ public class TrainSeparateNerExample {
             System.out.print("   Score: " + scoreStr + ": " + tag + ":");
             NerExample.printEntity(testStringVector, entity);
         }
-
-
     }
 }

--- a/examples/java/run_train_separate_ner.sh
+++ b/examples/java/run_train_separate_ner.sh
@@ -1,0 +1,10 @@
+# temporarily add the path to the mitie shared library to the proper linux and
+# mac os environment variables respectively
+export LD_LIBRARY_PATH=../../mitielib 
+export DYLD_LIBRARY_PATH=../../mitielib 
+
+export CLASSPATH=../../mitielib/javamitie.jar:. 
+
+javac TrainSeparateNerExample.java
+
+java TrainSeparateNerExample

--- a/mitielib/include/mitie/named_entity_extractor.h
+++ b/mitielib/include/mitie/named_entity_extractor.h
@@ -161,6 +161,15 @@ namespace mitie
         const total_word_feature_extractor& get_total_word_feature_extractor(
         ) const { return fe; }
 
+        const dlib::sequence_segmenter<ner_feature_extractor>& get_segmenter() const {
+            return segmenter;
+        }
+
+        const dlib::multiclass_linear_decision_function<dlib::sparse_linear_kernel<ner_sample_type>,unsigned long>& get_df() const {
+            return df;
+        };
+
+
     private:
         void compute_fingerprint()
         {

--- a/mitielib/include/mitie/named_entity_extractor.h
+++ b/mitielib/include/mitie/named_entity_extractor.h
@@ -43,9 +43,7 @@ namespace mitie
             const dlib::multiclass_linear_decision_function<dlib::sparse_linear_kernel<ner_sample_type>,unsigned long>& df
         );
 
-        named_entity_extractor(const std::string& dfName,
-                               const std::string& segmenterName,
-                               const std::string& tagStringsName,
+        named_entity_extractor(const std::string& pureModelName,
                                const std::string& extractorName
         );
 

--- a/mitielib/include/mitie/named_entity_extractor.h
+++ b/mitielib/include/mitie/named_entity_extractor.h
@@ -41,7 +41,14 @@ namespace mitie
             const total_word_feature_extractor& fe,
             const dlib::sequence_segmenter<ner_feature_extractor>& segmenter,
             const dlib::multiclass_linear_decision_function<dlib::sparse_linear_kernel<ner_sample_type>,unsigned long>& df
-        ); 
+        );
+
+        named_entity_extractor(const std::string& dfName,
+                               const std::string& segmenterName,
+                               const std::string& tagStringsName,
+                               const std::string& extractorName
+        );
+
         /*!
             requires
                 - segmenter.get_feature_extractor().num_features() == fe.get_num_dimensions() 

--- a/mitielib/java/swig_api.h
+++ b/mitielib/java/swig_api.h
@@ -23,7 +23,6 @@
 #include <mitie/binary_relation_detector.h>
 #include <mitie/named_entity_extractor.h>
 #include <mitie/ner_trainer.h>
-#include <mitie/ner_feature_extraction.h>
 
 
 // ----------------------------------------------------------------------------------------

--- a/mitielib/java/swig_api.h
+++ b/mitielib/java/swig_api.h
@@ -124,11 +124,9 @@ public:
         dlib::deserialize(filename) >> classname >> impl;
     }
 
-    NamedEntityExtractor(const std::string& dfName,
-               const std::string& segmenterName,
-               const std::string& tagStringsName,
+    NamedEntityExtractor(const std::string& pureModelName,
                const std::string& extractorName
-    ) :impl(dfName, segmenterName, tagStringsName, extractorName)
+    ) :impl(pureModelName, extractorName)
     {
 
     }
@@ -289,9 +287,11 @@ public:
     void trainSeparateModels(const std::string& filename) const
     {
         mitie::named_entity_extractor obj = impl.train();
-        dlib::serialize(filename+".df.dat") << "mitie::named_entity_extractor_df" << obj.get_df();
-        dlib::serialize(filename+".segmenter.dat") << "mitie::named_entity_extractor_segmenter" << obj.get_segmenter();
-        dlib::serialize(filename+".tns.dat") << "mitie::named_entity_extractor_tns" << obj.get_tag_name_strings();
+        dlib::serialize(filename)
+        << "mitie::named_entity_extractor_pure_model"
+        << obj.get_df()
+        << obj.get_segmenter()
+        << obj.get_tag_name_strings();
     }
 private:
     mitie::ner_trainer impl;

--- a/mitielib/java/swig_api.h
+++ b/mitielib/java/swig_api.h
@@ -125,35 +125,13 @@ public:
         dlib::deserialize(filename) >> classname >> impl;
     }
 
-    NerTrainer(const std::string& dfName, const std::string& segmenterName, const std::string& tagStringsName, const std::string& extractorName ) {
-        std::string classname;
-        dlib::deserialize(dfName) >> classname;
-        if (classname != "mitie::named_entity_extractor_dl")
-            throw dlib::error("This file does not contain a mitie::named_entity_extractor. Contained: " + classname);
+    NamedEntityExtractor(const std::string& dfName,
+               const std::string& segmenterName,
+               const std::string& tagStringsName,
+               const std::string& extractorName
+    ) :impl(dfName, segmenterName, tagStringsName, extractorName)
+    {
 
-        dlib::multiclass_linear_decision_function<dlib::sparse_linear_kernel<ner_sample_type>,unsigned long> df;
-        dlib::deserialize(filename) >> classname >> df;
-
-
-        dlib::deserialize(segmenterName) >> classname;
-        if (classname != "mitie::named_entity_extractor_segmenter")
-            throw dlib::error("This file does not contain a mitie::named_entity_extractor. Contained: " + classname);
-
-        dlib::sequence_segmenter<ner_feature_extractor> segmenter;
-        dlib::deserialize(segmenterName) >> classname >> segmenter;
-
-        dlib::deserialize(tagStringsName) >> classname;
-        if (classname != "mitie::named_entity_extractor_tns")
-            throw dlib::error("This file does not contain a mitie::named_entity_extractor. Contained: " + classname);
-
-        std::vector<std::string> tns;
-        dlib::deserialize(tagStringsName) >> classname >> tns;
-
-
-        total_word_feature_extractor twfe;
-        dlib::deserialize(extractorName) >> classname >> twfe;
-
-        impl = mitie::named_entity_extractor(tns, twfe, segmenter, df);
     }
 
     std::vector<std::string> getPossibleNerTags (
@@ -303,7 +281,13 @@ public:
         impl.set_num_threads(num);
     }
 
-    void train(const std::string& filename) const 
+    void train(const std::string& filename) const
+    {
+        mitie::named_entity_extractor obj = impl.train();
+        dlib::serialize(filename) << "mitie::named_entity_extractor" << obj;
+    }
+
+    void trainSeparateModels(const std::string& filename) const
     {
         mitie::named_entity_extractor obj = impl.train();
         dlib::serialize(filename+".df.dat") << "mitie::named_entity_extractor_df" << obj.get_df();

--- a/mitielib/src/named_entity_extractor.cpp
+++ b/mitielib/src/named_entity_extractor.cpp
@@ -3,7 +3,6 @@
 // Authors: Davis E. King (davis@dlib.net)
 
 #include <mitie/named_entity_extractor.h>
-#include <set>
 
 using namespace dlib;
 
@@ -41,21 +40,25 @@ namespace mitie
         std::string classname;
         dlib::deserialize(dfName) >> classname;
         if (classname != "mitie::named_entity_extractor_df")
-            throw dlib::error("This file does not contain a mitie::named_entity_extractor. Contained: " + classname);
+            throw dlib::error("This file does not contain a mitie::named_entity_extractor_df. Contained: " + classname);
 
         dlib::deserialize(dfName) >> classname >> df;
 
         dlib::deserialize(segmenterName) >> classname;
         if (classname != "mitie::named_entity_extractor_segmenter")
-            throw dlib::error("This file does not contain a mitie::named_entity_extractor. Contained: " + classname);
+            throw dlib::error("This file does not contain a mitie::named_entity_extractor_segmenter. Contained: " + classname);
 
         dlib::deserialize(segmenterName) >> classname >> segmenter;
 
         dlib::deserialize(tagStringsName) >> classname;
         if (classname != "mitie::named_entity_extractor_tns")
-            throw dlib::error("This file does not contain a mitie::named_entity_extractor. Contained: " + classname);
+            throw dlib::error("This file does not contain a mitie::named_entity_extractor_tns. Contained: " + classname);
 
         dlib::deserialize(tagStringsName) >> classname >> tag_name_strings;
+
+        dlib::deserialize(extractorName) >> classname;
+        if (classname != "mitie::total_word_feature_extractor")
+            throw dlib::error("This file does not contain a mitie::total_word_feature_extractor. Contained: " + classname);
 
         dlib::deserialize(extractorName) >> classname >> fe;
     }

--- a/mitielib/src/named_entity_extractor.cpp
+++ b/mitielib/src/named_entity_extractor.cpp
@@ -32,33 +32,21 @@ namespace mitie
     }
 
     named_entity_extractor::
-    named_entity_extractor(const std::string& dfName,
-                           const std::string& segmenterName,
-                           const std::string& tagStringsName,
+    named_entity_extractor(const std::string& pureModelName,
                            const std::string& extractorName
     ) {
         std::string classname;
-        dlib::deserialize(dfName) >> classname;
-        if (classname != "mitie::named_entity_extractor_df")
-            throw dlib::error("This file does not contain a mitie::named_entity_extractor_df. Contained: " + classname);
+        dlib::deserialize(pureModelName) >> classname;
+        if (classname != "mitie::named_entity_extractor_pure_model")
+            throw dlib::error(
+                    "This file does not contain a mitie::named_entity_extractor_pure_model. Contained: " + classname);
 
-        dlib::deserialize(dfName) >> classname >> df;
-
-        dlib::deserialize(segmenterName) >> classname;
-        if (classname != "mitie::named_entity_extractor_segmenter")
-            throw dlib::error("This file does not contain a mitie::named_entity_extractor_segmenter. Contained: " + classname);
-
-        dlib::deserialize(segmenterName) >> classname >> segmenter;
-
-        dlib::deserialize(tagStringsName) >> classname;
-        if (classname != "mitie::named_entity_extractor_tns")
-            throw dlib::error("This file does not contain a mitie::named_entity_extractor_tns. Contained: " + classname);
-
-        dlib::deserialize(tagStringsName) >> classname >> tag_name_strings;
+        dlib::deserialize(pureModelName) >> classname >> df >> segmenter >> tag_name_strings;
 
         dlib::deserialize(extractorName) >> classname;
         if (classname != "mitie::total_word_feature_extractor")
-            throw dlib::error("This file does not contain a mitie::total_word_feature_extractor. Contained: " + classname);
+            throw dlib::error(
+                    "This file does not contain a mitie::total_word_feature_extractor. Contained: " + classname);
 
         dlib::deserialize(extractorName) >> classname >> fe;
     }

--- a/mitielib/src/named_entity_extractor.cpp
+++ b/mitielib/src/named_entity_extractor.cpp
@@ -32,6 +32,33 @@ namespace mitie
         compute_fingerprint();
     }
 
+    named_entity_extractor::
+    named_entity_extractor(const std::string& dfName,
+                           const std::string& segmenterName,
+                           const std::string& tagStringsName,
+                           const std::string& extractorName
+    ) {
+        std::string classname;
+        dlib::deserialize(dfName) >> classname;
+        if (classname != "mitie::named_entity_extractor_df")
+            throw dlib::error("This file does not contain a mitie::named_entity_extractor. Contained: " + classname);
+
+        dlib::deserialize(dfName) >> classname >> df;
+
+        dlib::deserialize(segmenterName) >> classname;
+        if (classname != "mitie::named_entity_extractor_segmenter")
+            throw dlib::error("This file does not contain a mitie::named_entity_extractor. Contained: " + classname);
+
+        dlib::deserialize(segmenterName) >> classname >> segmenter;
+
+        dlib::deserialize(tagStringsName) >> classname;
+        if (classname != "mitie::named_entity_extractor_tns")
+            throw dlib::error("This file does not contain a mitie::named_entity_extractor. Contained: " + classname);
+
+        dlib::deserialize(tagStringsName) >> classname >> tag_name_strings;
+
+        dlib::deserialize(extractorName) >> classname >> fe;
+    }
 // ----------------------------------------------------------------------------------------
 
     void named_entity_extractor::


### PR DESCRIPTION
Hi Davis,

We also need to reduce the size of models. Since the extractor remains the same, we would like to separate the model from feature extractor. As a result, we create this pull request to be able to 

* train the model by outputting segmenter, model, and tag names into three different files.
* restore the extractor by reading the three different files.

Please review. Thanks.