### PR TITLE
Add python packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include makefile
+include mitielib/makefile
+recursive-include mitielib/src *
+recursive-include mitielib/include *
+recursive-include dlib/dlib *
+recursive-exclude * *.py[co]

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ MITIE: [named entity recognition and relation extraction](examples/python/ner.py
 [training a custom NER tool](examples/python/train_ner.py), or 
 [training a custom relation extractor](examples/python/train_relation_extraction.py).
 
+You can also install ``mitie`` package direcly from github:
+``pip install git+https://github.com/mit-nlp/MITIE.git``.
+
 ### Using MITIE from R
 
 MITIE can be installed as an R package. See the [README](tools/R-binding) for more details.

--- a/mitielib/__init__.py
+++ b/mitielib/__init__.py
@@ -1,0 +1,1 @@
+from .mitie import *

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,16 @@ setup(
     packages=['mitie'],
     package_dir={'mitie': 'mitielib'},
     cmdclass={'build': BuildMITIE},
+    classifiers=[
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: POSIX',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'License :: Boost License',
+        ]
     )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+import os.path
+from distutils.core import setup
+from distutils.command.build import build
+
+import subprocess
+
+
+class BuildMITIE(build):
+    def run(self):
+        subprocess.check_call(['make', 'mitielib'])
+        build.run(self)
+        self.copy_file(
+            'mitielib/libmitie.so',
+             os.path.join(self.build_lib, 'mitie/libmitie.so'))
+
+
+setup(
+    version='0.2.0',
+    name='mitie',
+    packages=['mitie'],
+    package_dir={'mitie': 'mitielib'},
+    cmdclass={'build': BuildMITIE},
+    )


### PR DESCRIPTION
We are currently using MITIE from python. Thanks for a great library! We would be like to be able to make it installable as a python package for the ease of installation, and others also might find it useful. In this PR I added a basic ``setup.py`` that installs everything from source (only on POSIX currently), so it is possible to install it with ``pip install git+https://github.com/lopuhin/MITIE.git@python-setup``. In order to support installation from github, I've put ``setup.py`` in the root directory, but if you are willing to put in on [PyPI](https://pypi.python.org), then it can be moved somewhere else.