### PR TITLE
python API for text categorizer

### DIFF
--- a/examples/python/categorize_text.py
+++ b/examples/python/categorize_text.py
@@ -1,25 +1,27 @@
 #!/usr/bin/python
 #
-#    This example shows how to use the MITIE Python API to train a named_entity_extractor.
+#    This example shows how to use the MITIE Python API to use a text_categorizer.
 #
 #
 import sys, os
-import ipdb
+
+
 # Make sure you put the mitielib folder into the python search path.  There are
 # a lot of ways to do this, here we do it programmatically with the following
 # two statements:
-#parent = os.path.dirname(os.path.realpath(__file__))
-#sys.path.append(parent + '/../../mitielib')
+parent = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(parent + '/../../mitielib')
 
 from mitie import *
 
 test_tokens = ["What","a","black","and","bad","day"]
 test_tokens_2 = ["I","am","so","happy"]
 
-# This function does the work of training.  Note that it can take a long time to run
-# when using larger training datasets.  So be patient.
+# load a pre-trained text categorizer
 cat = text_categorizer("new_text_categorizer.dat")
 
+# call the categorizer with a list of tokens, the response is a label (a string)
+# and a score (a number) indicating the confidence of the categorizer
 label, score = cat(test_tokens)
 print(label,score)
 

--- a/examples/python/categorize_text.py
+++ b/examples/python/categorize_text.py
@@ -14,10 +14,15 @@ import ipdb
 from mitie import *
 
 test_tokens = ["What","a","black","and","bad","day"]
+test_tokens_2 = ["I","am","so","happy"]
 
 # This function does the work of training.  Note that it can take a long time to run
 # when using larger training datasets.  So be patient.
-cat = text_categorizer("new_text_categorizer2.dat")
+cat = text_categorizer("new_text_categorizer.dat")
 
 label, score = cat(test_tokens)
+print(label,score)
+
+
+label, score = cat(test_tokens_2)
 print(label,score)

--- a/examples/python/categorize_text.py
+++ b/examples/python/categorize_text.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+#
+#    This example shows how to use the MITIE Python API to train a named_entity_extractor.
+#
+#
+import sys, os
+import ipdb
+# Make sure you put the mitielib folder into the python search path.  There are
+# a lot of ways to do this, here we do it programmatically with the following
+# two statements:
+#parent = os.path.dirname(os.path.realpath(__file__))
+#sys.path.append(parent + '/../../mitielib')
+
+from mitie import *
+
+test_tokens = ["What","a","black","and","bad","day"]
+
+# This function does the work of training.  Note that it can take a long time to run
+# when using larger training datasets.  So be patient.
+cat = text_categorizer("new_text_categorizer2.dat")
+
+label, score = cat(test_tokens)
+print(label,score)

--- a/examples/python/train_text_categorizer.py
+++ b/examples/python/train_text_categorizer.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+#
+#    This example shows how to use the MITIE Python API to train a named_entity_extractor.
+#
+#
+import sys, os
+# Make sure you put the mitielib folder into the python search path.  There are
+# a lot of ways to do this, here we do it programmatically with the following
+# two statements:
+parent = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(parent + '/../../mitielib')
+
+from mitie import *
+
+
+trainer = text_categorizer_trainer("../../MITIE-models/english/total_word_feature_extractor.dat")
+print(trainer)
+# Don't forget to add the training data.  Here we have only two examples, but for real
+# uses you need to have thousands.
+
+
+trainer.add_labeled_text(["I","am","so","happy","and","exciting","to","make","this"],"positive")
+trainer.add_labeled_text(["What","a","black","and","bad","day"],"negative")
+exit(0)
+# The trainer can take advantage of a multi-core CPU.  So set the number of threads
+# equal to the number of processing cores for maximum training speed.
+trainer.num_threads = 4
+
+
+# This function does the work of training.  Note that it can take a long time to run
+# when using larger training datasets.  So be patient.
+cat = trainer.train()
+
+# Now that training is done we can save the ner object to disk like so.  This will
+# allow you to load the model back in using a statement like:
+#   ner = named_entity_extractor("new_ner_model.dat").
+cat.save_to_disk("new_text_categorizer.dat")
+

--- a/examples/python/train_text_categorizer.py
+++ b/examples/python/train_text_categorizer.py
@@ -4,24 +4,24 @@
 #
 #
 import sys, os
+import ipdb
 # Make sure you put the mitielib folder into the python search path.  There are
 # a lot of ways to do this, here we do it programmatically with the following
 # two statements:
-parent = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(parent + '/../../mitielib')
+#parent = os.path.dirname(os.path.realpath(__file__))
+#sys.path.append(parent + '/../../mitielib')
 
 from mitie import *
 
 
-trainer = text_categorizer_trainer("../../MITIE-models/english/total_word_feature_extractor.dat")
-print(trainer)
+trainer = text_categorizer_trainer("../../../MITIE-models/english/total_word_feature_extractor.dat")
 # Don't forget to add the training data.  Here we have only two examples, but for real
 # uses you need to have thousands.
 
 
 trainer.add_labeled_text(["I","am","so","happy","and","exciting","to","make","this"],"positive")
 trainer.add_labeled_text(["What","a","black","and","bad","day"],"negative")
-exit(0)
+
 # The trainer can take advantage of a multi-core CPU.  So set the number of threads
 # equal to the number of processing cores for maximum training speed.
 trainer.num_threads = 4
@@ -34,5 +34,5 @@ cat = trainer.train()
 # Now that training is done we can save the ner object to disk like so.  This will
 # allow you to load the model back in using a statement like:
 #   ner = named_entity_extractor("new_ner_model.dat").
-cat.save_to_disk("new_text_categorizer.dat")
+cat.save_to_disk("new_text_categorizer2.dat")
 

--- a/examples/python/train_text_categorizer.py
+++ b/examples/python/train_text_categorizer.py
@@ -1,24 +1,24 @@
 #!/usr/bin/python
 #
-#    This example shows how to use the MITIE Python API to train a named_entity_extractor.
+#    This example shows how to use the MITIE Python API to train a text_categorizer.
 #
 #
 import sys, os
-import ipdb
+
 # Make sure you put the mitielib folder into the python search path.  There are
 # a lot of ways to do this, here we do it programmatically with the following
 # two statements:
-#parent = os.path.dirname(os.path.realpath(__file__))
-#sys.path.append(parent + '/../../mitielib')
+parent = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(parent + '/../../mitielib')
 
 from mitie import *
 
 
-trainer = text_categorizer_trainer("../../../MITIE-models/english/total_word_feature_extractor.dat")
+trainer = text_categorizer_trainer("../../MITIE-models/english/total_word_feature_extractor.dat")
+
 # Don't forget to add the training data.  Here we have only two examples, but for real
-# uses you need to have thousands.
-
-
+# uses you need to have thousands. You could also pass whole sentences in to the tokenize() function
+# to get the tokens.
 trainer.add_labeled_text(["I","am","so","happy","and","exciting","to","make","this"],"positive")
 trainer.add_labeled_text(["What","a","black","and","bad","day"],"negative")
 
@@ -31,8 +31,8 @@ trainer.num_threads = 4
 # when using larger training datasets.  So be patient.
 cat = trainer.train()
 
-# Now that training is done we can save the ner object to disk like so.  This will
+# Now that training is done we can save the categorizer object to disk like so.  This will
 # allow you to load the model back in using a statement like:
-#   ner = named_entity_extractor("new_ner_model.dat").
+#   cat = text_categorizer("new_text_categorizer.dat").
 cat.save_to_disk("new_text_categorizer.dat")
 

--- a/examples/python/train_text_categorizer.py
+++ b/examples/python/train_text_categorizer.py
@@ -34,5 +34,5 @@ cat = trainer.train()
 # Now that training is done we can save the ner object to disk like so.  This will
 # allow you to load the model back in using a statement like:
 #   ner = named_entity_extractor("new_ner_model.dat").
-cat.save_to_disk("new_text_categorizer2.dat")
+cat.save_to_disk("new_text_categorizer.dat")
 

--- a/mitielib/include/mitie.h
+++ b/mitielib/include/mitie.h
@@ -392,7 +392,7 @@ extern "C"
             - filename == a valid pointer to a NULL terminated C string
         ensures
             - Reads a saved MITIE text categorizer object from disk and returns a
-              pointer to the relation detector.
+              pointer to the text categorizer.
             - The returned object MUST BE FREED by a call to mitie_free().
             - If the object can't be created then this function returns NULL.
     !*/
@@ -404,7 +404,17 @@ extern "C"
         double* text_score      
     );
     /*!
-        requires
+        requires            
+            - tcat_ != NULL
+            - tokens != NULL
+            - text_tag != NULL
+            - text_score != NULL        
+        ensures
+          - returns 0 upon success and a non-zero value on failure.  
+          - if (this function returns 0) then
+              - **text_tag == the predicted category to which this text belongs 
+                 (selected from the set of categories tcat_ knows about)
+              - *score == the confidence the categorizer has about its prediction.
     !*/
 
 
@@ -454,7 +464,7 @@ extern "C"
     /*!
         requires
             - filename == a valid pointer to a NULL terminated C string
-            - ner != NULL
+            - tcat != NULL
         ensures
             - Saves the given text categorizer object to disk in a file with the given filename.  Once this function
               finishes you will be able to read the ner object from disk by calling
@@ -907,14 +917,7 @@ extern "C"
             - returns the trainer's beta parameter.  This parameter controls the trade-off
               between trying to avoid false alarms but also detecting everything.
               Different values of beta have the following interpretations:
-                - beta < 1 indicates that you care more about avoiding false alarms than
-                  missing detections.  The smaller you make beta the more the trainer will
-                  try to avoid false alarms.
-                - beta == 1 indicates that you don't have a preference between avoiding
-                  false alarms or not missing detections.  That is, you care about these
-                  two things equally.
-                - beta > 1 indicates that care more about not missing detections than
-                  avoiding false alarms.
+              // TODO write interpretations of beta parameter
     !*/
 
     MITIE_EXPORT void mitie_text_categorizer_trainer_set_num_threads (
@@ -936,19 +939,19 @@ extern "C"
             - trainer != NULL
         ensures
             - returns the number of threads the trainer will use when
-              mitie_train_named_entity_extractor() is called.  You should set this equal to
+              mitie_train_text_categorizer() is called.  You should set this equal to
               the number of available CPU cores for maximum training speed.
     !*/
 
     MITIE_EXPORT int mitie_add_text_categorizer_labeled_text (
         mitie_text_categorizer_trainer* trainer,
-        char** tokens,
+        const char** tokens,
         const char* label
     );
     /*!
         requires
-            - trainer != NULL
-            - instance != NULL
+            - tokens != NULL
+            - label != NULL
         ensures
             - Adds the given training example to the trainer object.
             - mitie_text_categorizer_trainer_size(trainer) is incremented by 1.
@@ -962,12 +965,10 @@ extern "C"
     /*!
         requires
             - trainer != NULL
-            - mitie_binary_relation_trainer_num_positive_examples(trainer) > 0
-            - mitie_binary_relation_trainer_num_negative_examples(trainer) > 0
+            - mitie_text_categorizer_trainer_size(trainer) > 0
         ensures
-            - Runs the binary relation training process based on the training data in the
-              given trainer.  Once finished, it returns the resulting binary relation
-              detector object.
+            - Runs the text categorizer training process based on the training data in the
+              given trainer.  Once finished, it returns the resulting text categorizer object.
             - The returned object MUST BE FREED by a call to mitie_free().
             - returns NULL if the object could not be created.
     !*/

--- a/mitielib/include/mitie.h
+++ b/mitielib/include/mitie.h
@@ -396,6 +396,17 @@ extern "C"
             - The returned object MUST BE FREED by a call to mitie_free().
             - If the object can't be created then this function returns NULL.
     !*/
+    
+    MITIE_EXPORT int mitie_categorize_text (
+        const mitie_text_categorizer* tcat_,
+        const char** tokens,
+        char* text_tag,
+        double* text_score      
+    );
+    /*!
+        requires
+    !*/
+
 
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
@@ -438,7 +449,7 @@ extern "C"
 
     MITIE_EXPORT int mitie_save_text_categorizer (
         const char* filename,
-        const mitie_text_categorizer* ner
+        const mitie_text_categorizer* tcat
     );
     /*!
         requires

--- a/mitielib/include/mitie.h
+++ b/mitielib/include/mitie.h
@@ -400,7 +400,7 @@ extern "C"
     MITIE_EXPORT int mitie_categorize_text (
         const mitie_text_categorizer* tcat_,
         const char** tokens,
-        char* text_tag,
+        char** text_tag,
         double* text_score      
     );
     /*!

--- a/mitielib/include/mitie.h
+++ b/mitielib/include/mitie.h
@@ -467,7 +467,7 @@ extern "C"
             - tcat != NULL
         ensures
             - Saves the given text categorizer object to disk in a file with the given filename.  Once this function
-              finishes you will be able to read the ner object from disk by calling
+              finishes you will be able to read the text categorizer object from disk by calling
               mitie_load_text_categorizer(filename).
             - returns 0 upon success and a non-zero value on failure.  Failure happens if
               there is some error that prevents us from writing to the given file.
@@ -917,7 +917,7 @@ extern "C"
             - returns the trainer's beta parameter.  This parameter controls the trade-off
               between trying to avoid false alarms but also detecting everything.
               Different values of beta have the following interpretations:
-              // TODO write interpretations of beta parameter
+              // TODO document interpretations of beta parameter
     !*/
 
     MITIE_EXPORT void mitie_text_categorizer_trainer_set_num_threads (

--- a/mitielib/include/mitie.h
+++ b/mitielib/include/mitie.h
@@ -36,7 +36,7 @@ extern "C"
     typedef struct mitie_named_entity_detections mitie_named_entity_detections;
 
     MITIE_EXPORT void mitie_free (
-        void* object
+        void* object 
     );
     /*!
         requires
@@ -70,9 +70,9 @@ extern "C"
         requires
             - text == a valid pointer to a NULL terminated C string
         ensures
-            - returns an array that contains a tokenized copy of the input text.
+            - returns an array that contains a tokenized copy of the input text.  
             - The returned array is an array of pointers to NULL terminated C strings.  The
-              array itself is terminated with a NULL.  So for example, if text was "some text"
+              array itself is terminated with a NULL.  So for example, if text was "some text" 
               then the returned array, TOK, would contain:
                 - TOK[0] == "some"
                 - TOK[1] == "text"
@@ -110,7 +110,7 @@ extern "C"
               data.  To say this precisely, let TOKENS refer to the returned char**.  Then
               we will have:
                 - (*token_offsets)[i] == the character offset into text for the first
-                  character in TOKENS[i].  That is, it will be the case that
+                  character in TOKENS[i].  That is, it will be the case that 
                   text[(*token_offsets)[i]+j]==tokens[i][j] for all valid i and j.
             - It is the responsibility of the caller to free the returned arrays.  This
               includes the *token_offsets array and also the returned char**.  You free
@@ -143,7 +143,7 @@ extern "C"
               the number of different tags which can be produced by the given named entity
               extractor.  Moreover, each tag is uniquely identified by a numeric ID which
               is just the index of the tag.  For example, if there are 4 possible tags then
-              the numeric IDs are just 0, 1, 2, and 3.
+              the numeric IDs are just 0, 1, 2, and 3.  
     !*/
 
     MITIE_EXPORT const char* mitie_get_named_entity_tagstr (
@@ -157,7 +157,7 @@ extern "C"
         ensures
             - Each named entity tag, in addition to having a numeric ID which uniquely
               identifies it, has a text string name.  For example, if a named entity tag
-              logically identifies a person then the tag string might be "PERSON".
+              logically identifies a person then the tag string might be "PERSON". 
             - This function takes a tag ID number and returns the tag string for that tag.
             - The returned pointer is valid until mitie_free(ner) is called.
     !*/
@@ -166,14 +166,14 @@ extern "C"
 
     MITIE_EXPORT mitie_named_entity_detections* mitie_extract_entities (
         const mitie_named_entity_extractor* ner,
-        char** tokens
+        char** tokens 
     );
     /*!
         requires
             - ner != NULL
             - tokens == An array of NULL terminated C strings.  The end of the array must
               be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
-              array of tokens).
+              array of tokens).  
         ensures
             - The returned object MUST BE FREED by a call to mitie_free().
             - Runs the supplied named entity extractor on the tokenized text and returns a
@@ -223,7 +223,7 @@ extern "C"
         ensures
             - returns the length of the idx-th named entity.  That is, this function
               returns the number of tokens from the input text which comprise the idx-th
-              named entity detection.
+              named entity detection.  
     !*/
 
     MITIE_EXPORT unsigned long mitie_ner_get_detection_tag (
@@ -248,7 +248,7 @@ extern "C"
             - idx < mitie_ner_get_num_detections(dets)
         ensures
             - returns a NULL terminated C string that identifies the type of the idx-th
-              named entity.
+              named entity. 
             - The returned pointer is valid until mitie_free(dets) is called.
     !*/
 
@@ -327,7 +327,7 @@ extern "C"
             - ner != NULL
             - tokens == An array of NULL terminated C strings.  The end of the array must
               be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
-              array of tokens).
+              array of tokens).  
             - arg1_length > 0
             - arg2_length > 0
             - The arg indices reference valid elements of the tokens array.  That is,
@@ -378,24 +378,25 @@ extern "C"
                   confident it is that the relation is a valid relation.
     !*/
 
-
+    
     // ----------------------------------------------------------------------------------------
 
-        typedef struct mitie_text_categorizer  mitie_text_categorizer;
-        typedef struct mitie_text_categorizer_trainer  mitie_text_categorizer_trainer;
+    typedef struct mitie_text_categorizer  mitie_text_categorizer;
+    typedef struct mitie_text_categorizer_trainer  mitie_text_categorizer_trainer;
 
-        MITIE_EXPORT mitie_text_categorizer* mitie_load_text_categorizer (
-            const char* filename
-        );
-        /*!
-            requires
-                - filename == a valid pointer to a NULL terminated C string
-            ensures
-                - Reads a saved MITIE text categorizer object from disk and returns a
-                  pointer to the relation detector.
-                - The returned object MUST BE FREED by a call to mitie_free().
-                - If the object can't be created then this function returns NULL.
-        !*/
+    MITIE_EXPORT mitie_text_categorizer* mitie_load_text_categorizer (
+        const char* filename
+    );
+    /*!
+        requires
+            - filename == a valid pointer to a NULL terminated C string
+        ensures
+            - Reads a saved MITIE text categorizer object from disk and returns a
+              pointer to the relation detector.
+            - The returned object MUST BE FREED by a call to mitie_free().
+            - If the object can't be created then this function returns NULL.
+    !*/
+
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 //                                      TRAINING ROUTINES
@@ -421,7 +422,7 @@ extern "C"
 
     MITIE_EXPORT int mitie_save_binary_relation_detector (
         const char* filename,
-        const mitie_binary_relation_detector* detector
+        const mitie_binary_relation_detector* detector 
     );
     /*!
         requires
@@ -450,7 +451,6 @@ extern "C"
             - returns 0 upon success and a non-zero value on failure.  Failure happens if
               there is some error that prevents us from writing to the given file.
     !*/
-
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 
@@ -464,7 +464,7 @@ extern "C"
         requires
             - tokens == An array of NULL terminated C strings.  The end of the array must
               be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
-              array of tokens).
+              array of tokens).  
         ensures
             - Creates and returns a NER training instance object.  You use it by calling
               mitie_add_ner_training_entity() to annotate which tokens participate in
@@ -529,10 +529,10 @@ extern "C"
             - label == a valid pointer to a NULL terminated C string
             - mitie_overlaps_any_entity(instance, start, length) == 0
         ensures
-            - Annotates the entity of length tokens at the given starting token with the
-              given NER label.
+            - Annotates the entity of length tokens at the given starting token with the 
+              given NER label.  
             - mitie_ner_training_instance_num_entities(instance) is increased by 1.
-            - returns 0 on success and a non-zero value on failure.  Failure might be
+            - returns 0 on success and a non-zero value on failure.  Failure might be 
               caused by running out of memory.
     !*/
 
@@ -543,11 +543,11 @@ extern "C"
         requires
             - filename == a valid pointer to a NULL terminated C string
         ensures
-            - Creates a NER trainer object and returns a pointer to it.
+            - Creates a NER trainer object and returns a pointer to it.  
             - filename should contain the name of a saved total_word_feature_extractor, as
               created by the wordrep tool's -e option (see the MITIE/tools/wordrep folder).
             - The returned object MUST BE FREED by a call to mitie_free().
-            - returns NULL if the object could not be created.
+            - returns NULL if the object could not be created. 
             - calling mitie_ner_trainer_get_beta() on the returned pointer returns 0.5.
               That is, the default beta value is 0.5.
             - calling mitie_ner_trainer_get_num_threads() on the returned pointer returns
@@ -577,7 +577,7 @@ extern "C"
         ensures
             - Adds the given training instance to the trainer object.
             - mitie_ner_trainer_size(trainer) is incremented by 1.
-            - returns 0 on success and a non-zero value on failure.  Failure might be
+            - returns 0 on success and a non-zero value on failure.  Failure might be 
               caused by running out of memory.
     !*/
 
@@ -590,7 +590,7 @@ extern "C"
             - trainer != NULL
             - beta >= 0
         ensures
-            - mitie_ner_trainer_get_beta(trainer) == beta
+            - mitie_ner_trainer_get_beta(trainer) == beta 
     !*/
 
     MITIE_EXPORT double mitie_ner_trainer_get_beta (
@@ -615,7 +615,7 @@ extern "C"
 
     MITIE_EXPORT void mitie_ner_trainer_set_num_threads (
         mitie_ner_trainer* trainer,
-        unsigned long num_threads
+        unsigned long num_threads 
     );
     /*!
         requires
@@ -650,7 +650,7 @@ extern "C"
             - The returned object MUST BE FREED by a call to mitie_free().
             - returns NULL if the object could not be created.
     !*/
-
+    
 // ----------------------------------------------------------------------------------------
 
     typedef struct mitie_binary_relation_trainer mitie_binary_relation_trainer;
@@ -664,7 +664,7 @@ extern "C"
             - relation_name == a valid NULL terminated C string
             - ner != NULL
         ensures
-            - Creates a binary relation trainer object and returns a pointer to it.
+            - Creates a binary relation trainer object and returns a pointer to it.  
             - The returned object MUST BE FREED by a call to mitie_free().
             - returns NULL if the object could not be created.
             - calling mitie_binary_relation_trainer_get_beta() on the returned pointer
@@ -673,10 +673,10 @@ extern "C"
               pointer returns 4.  That is, the default number of threads to use is 4.
             - calling mitie_binary_relation_trainer_num_positive_examples() on the returned
               pointer returns 0.  That is, initially the trainer has no positive training
-              instances in it.
+              instances in it. 
             - calling mitie_binary_relation_trainer_num_negative_examples() on the returned
               pointer returns 0.  That is, initially the trainer has no negative training
-              instances in it.
+              instances in it. 
     !*/
 
     MITIE_EXPORT unsigned long mitie_binary_relation_trainer_num_positive_examples (
@@ -712,7 +712,7 @@ extern "C"
             - trainer != NULL
             - tokens == An array of NULL terminated C strings.  The end of the array must
               be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
-              array of tokens).
+              array of tokens).  
             - arg1_length > 0
             - arg2_length > 0
             - The arg indices reference valid elements of the tokens array.  That is,
@@ -747,7 +747,7 @@ extern "C"
             - trainer != NULL
             - tokens == An array of NULL terminated C strings.  The end of the array must
               be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
-              array of tokens).
+              array of tokens).  
             - arg1_length > 0
             - arg2_length > 0
             - The arg indices reference valid elements of the tokens array.  That is,
@@ -762,7 +762,7 @@ extern "C"
               this function tells the trainer that the given tokens and argument
               combination is not a binary relation we are trying to learn.  The argument
               indices have the same interpretation as they do for
-              mitie_add_positive_binary_relation().
+              mitie_add_positive_binary_relation(). 
             - mitie_binary_relation_trainer_num_negative_examples(trainer) is incremented by 1.
             - returns 0 on success and a non-zero value on failure.  Failure might
               happen if we run out of memory.
@@ -777,7 +777,7 @@ extern "C"
             - trainer != NULL
             - beta >= 0
         ensures
-            - mitie_binary_relation_trainer_get_beta(trainer) == beta
+            - mitie_binary_relation_trainer_get_beta(trainer) == beta 
     !*/
 
     MITIE_EXPORT double mitie_binary_relation_trainer_get_beta (
@@ -802,7 +802,7 @@ extern "C"
 
     MITIE_EXPORT void mitie_binary_relation_trainer_set_num_threads (
         mitie_binary_relation_trainer* trainer,
-        unsigned long num_threads
+        unsigned long num_threads 
     );
     /*!
         requires
@@ -838,7 +838,7 @@ extern "C"
             - The returned object MUST BE FREED by a call to mitie_free().
             - returns NULL if the object could not be created.
     !*/
-// ----------------------------------------------------------------------------------------
+    // ----------------------------------------------------------------------------------------
 
     typedef struct mitie_text_categorizer_trainer mitie_text_categorizer_trainer;
 
@@ -963,6 +963,8 @@ extern "C"
 
 
 // ----------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 
 #ifdef __cplusplus
@@ -970,3 +972,4 @@ extern "C"
 #endif
 
 #endif // MITLL_MITIe_H_
+

--- a/mitielib/include/mitie.h
+++ b/mitielib/include/mitie.h
@@ -36,7 +36,7 @@ extern "C"
     typedef struct mitie_named_entity_detections mitie_named_entity_detections;
 
     MITIE_EXPORT void mitie_free (
-        void* object 
+        void* object
     );
     /*!
         requires
@@ -70,9 +70,9 @@ extern "C"
         requires
             - text == a valid pointer to a NULL terminated C string
         ensures
-            - returns an array that contains a tokenized copy of the input text.  
+            - returns an array that contains a tokenized copy of the input text.
             - The returned array is an array of pointers to NULL terminated C strings.  The
-              array itself is terminated with a NULL.  So for example, if text was "some text" 
+              array itself is terminated with a NULL.  So for example, if text was "some text"
               then the returned array, TOK, would contain:
                 - TOK[0] == "some"
                 - TOK[1] == "text"
@@ -110,7 +110,7 @@ extern "C"
               data.  To say this precisely, let TOKENS refer to the returned char**.  Then
               we will have:
                 - (*token_offsets)[i] == the character offset into text for the first
-                  character in TOKENS[i].  That is, it will be the case that 
+                  character in TOKENS[i].  That is, it will be the case that
                   text[(*token_offsets)[i]+j]==tokens[i][j] for all valid i and j.
             - It is the responsibility of the caller to free the returned arrays.  This
               includes the *token_offsets array and also the returned char**.  You free
@@ -143,7 +143,7 @@ extern "C"
               the number of different tags which can be produced by the given named entity
               extractor.  Moreover, each tag is uniquely identified by a numeric ID which
               is just the index of the tag.  For example, if there are 4 possible tags then
-              the numeric IDs are just 0, 1, 2, and 3.  
+              the numeric IDs are just 0, 1, 2, and 3.
     !*/
 
     MITIE_EXPORT const char* mitie_get_named_entity_tagstr (
@@ -157,7 +157,7 @@ extern "C"
         ensures
             - Each named entity tag, in addition to having a numeric ID which uniquely
               identifies it, has a text string name.  For example, if a named entity tag
-              logically identifies a person then the tag string might be "PERSON". 
+              logically identifies a person then the tag string might be "PERSON".
             - This function takes a tag ID number and returns the tag string for that tag.
             - The returned pointer is valid until mitie_free(ner) is called.
     !*/
@@ -166,14 +166,14 @@ extern "C"
 
     MITIE_EXPORT mitie_named_entity_detections* mitie_extract_entities (
         const mitie_named_entity_extractor* ner,
-        char** tokens 
+        char** tokens
     );
     /*!
         requires
             - ner != NULL
             - tokens == An array of NULL terminated C strings.  The end of the array must
               be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
-              array of tokens).  
+              array of tokens).
         ensures
             - The returned object MUST BE FREED by a call to mitie_free().
             - Runs the supplied named entity extractor on the tokenized text and returns a
@@ -223,7 +223,7 @@ extern "C"
         ensures
             - returns the length of the idx-th named entity.  That is, this function
               returns the number of tokens from the input text which comprise the idx-th
-              named entity detection.  
+              named entity detection.
     !*/
 
     MITIE_EXPORT unsigned long mitie_ner_get_detection_tag (
@@ -248,7 +248,7 @@ extern "C"
             - idx < mitie_ner_get_num_detections(dets)
         ensures
             - returns a NULL terminated C string that identifies the type of the idx-th
-              named entity. 
+              named entity.
             - The returned pointer is valid until mitie_free(dets) is called.
     !*/
 
@@ -327,7 +327,7 @@ extern "C"
             - ner != NULL
             - tokens == An array of NULL terminated C strings.  The end of the array must
               be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
-              array of tokens).  
+              array of tokens).
             - arg1_length > 0
             - arg2_length > 0
             - The arg indices reference valid elements of the tokens array.  That is,
@@ -378,6 +378,24 @@ extern "C"
                   confident it is that the relation is a valid relation.
     !*/
 
+
+    // ----------------------------------------------------------------------------------------
+
+        typedef struct mitie_text_categorizer  mitie_text_categorizer;
+        typedef struct mitie_text_categorizer_trainer  mitie_text_categorizer_trainer;
+
+        MITIE_EXPORT mitie_text_categorizer* mitie_load_text_categorizer (
+            const char* filename
+        );
+        /*!
+            requires
+                - filename == a valid pointer to a NULL terminated C string
+            ensures
+                - Reads a saved MITIE text categorizer object from disk and returns a
+                  pointer to the relation detector.
+                - The returned object MUST BE FREED by a call to mitie_free().
+                - If the object can't be created then this function returns NULL.
+        !*/
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 //                                      TRAINING ROUTINES
@@ -403,7 +421,7 @@ extern "C"
 
     MITIE_EXPORT int mitie_save_binary_relation_detector (
         const char* filename,
-        const mitie_binary_relation_detector* detector 
+        const mitie_binary_relation_detector* detector
     );
     /*!
         requires
@@ -413,6 +431,22 @@ extern "C"
             - Saves the given detector object to disk in a file with the given filename.
               Once this function finishes you will be able to read the detector object from
               disk by calling mitie_load_binary_relation_detector(filename).
+            - returns 0 upon success and a non-zero value on failure.  Failure happens if
+              there is some error that prevents us from writing to the given file.
+    !*/
+
+    MITIE_EXPORT int mitie_save_text_categorizer (
+        const char* filename,
+        const mitie_text_categorizer* ner
+    );
+    /*!
+        requires
+            - filename == a valid pointer to a NULL terminated C string
+            - ner != NULL
+        ensures
+            - Saves the given text categorizer object to disk in a file with the given filename.  Once this function
+              finishes you will be able to read the ner object from disk by calling
+              mitie_load_text_categorizer(filename).
             - returns 0 upon success and a non-zero value on failure.  Failure happens if
               there is some error that prevents us from writing to the given file.
     !*/
@@ -430,7 +464,7 @@ extern "C"
         requires
             - tokens == An array of NULL terminated C strings.  The end of the array must
               be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
-              array of tokens).  
+              array of tokens).
         ensures
             - Creates and returns a NER training instance object.  You use it by calling
               mitie_add_ner_training_entity() to annotate which tokens participate in
@@ -495,10 +529,10 @@ extern "C"
             - label == a valid pointer to a NULL terminated C string
             - mitie_overlaps_any_entity(instance, start, length) == 0
         ensures
-            - Annotates the entity of length tokens at the given starting token with the 
-              given NER label.  
+            - Annotates the entity of length tokens at the given starting token with the
+              given NER label.
             - mitie_ner_training_instance_num_entities(instance) is increased by 1.
-            - returns 0 on success and a non-zero value on failure.  Failure might be 
+            - returns 0 on success and a non-zero value on failure.  Failure might be
               caused by running out of memory.
     !*/
 
@@ -509,11 +543,11 @@ extern "C"
         requires
             - filename == a valid pointer to a NULL terminated C string
         ensures
-            - Creates a NER trainer object and returns a pointer to it.  
+            - Creates a NER trainer object and returns a pointer to it.
             - filename should contain the name of a saved total_word_feature_extractor, as
               created by the wordrep tool's -e option (see the MITIE/tools/wordrep folder).
             - The returned object MUST BE FREED by a call to mitie_free().
-            - returns NULL if the object could not be created. 
+            - returns NULL if the object could not be created.
             - calling mitie_ner_trainer_get_beta() on the returned pointer returns 0.5.
               That is, the default beta value is 0.5.
             - calling mitie_ner_trainer_get_num_threads() on the returned pointer returns
@@ -543,7 +577,7 @@ extern "C"
         ensures
             - Adds the given training instance to the trainer object.
             - mitie_ner_trainer_size(trainer) is incremented by 1.
-            - returns 0 on success and a non-zero value on failure.  Failure might be 
+            - returns 0 on success and a non-zero value on failure.  Failure might be
               caused by running out of memory.
     !*/
 
@@ -556,7 +590,7 @@ extern "C"
             - trainer != NULL
             - beta >= 0
         ensures
-            - mitie_ner_trainer_get_beta(trainer) == beta 
+            - mitie_ner_trainer_get_beta(trainer) == beta
     !*/
 
     MITIE_EXPORT double mitie_ner_trainer_get_beta (
@@ -581,7 +615,7 @@ extern "C"
 
     MITIE_EXPORT void mitie_ner_trainer_set_num_threads (
         mitie_ner_trainer* trainer,
-        unsigned long num_threads 
+        unsigned long num_threads
     );
     /*!
         requires
@@ -616,7 +650,7 @@ extern "C"
             - The returned object MUST BE FREED by a call to mitie_free().
             - returns NULL if the object could not be created.
     !*/
-    
+
 // ----------------------------------------------------------------------------------------
 
     typedef struct mitie_binary_relation_trainer mitie_binary_relation_trainer;
@@ -630,7 +664,7 @@ extern "C"
             - relation_name == a valid NULL terminated C string
             - ner != NULL
         ensures
-            - Creates a binary relation trainer object and returns a pointer to it.  
+            - Creates a binary relation trainer object and returns a pointer to it.
             - The returned object MUST BE FREED by a call to mitie_free().
             - returns NULL if the object could not be created.
             - calling mitie_binary_relation_trainer_get_beta() on the returned pointer
@@ -639,10 +673,10 @@ extern "C"
               pointer returns 4.  That is, the default number of threads to use is 4.
             - calling mitie_binary_relation_trainer_num_positive_examples() on the returned
               pointer returns 0.  That is, initially the trainer has no positive training
-              instances in it. 
+              instances in it.
             - calling mitie_binary_relation_trainer_num_negative_examples() on the returned
               pointer returns 0.  That is, initially the trainer has no negative training
-              instances in it. 
+              instances in it.
     !*/
 
     MITIE_EXPORT unsigned long mitie_binary_relation_trainer_num_positive_examples (
@@ -678,7 +712,7 @@ extern "C"
             - trainer != NULL
             - tokens == An array of NULL terminated C strings.  The end of the array must
               be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
-              array of tokens).  
+              array of tokens).
             - arg1_length > 0
             - arg2_length > 0
             - The arg indices reference valid elements of the tokens array.  That is,
@@ -713,7 +747,7 @@ extern "C"
             - trainer != NULL
             - tokens == An array of NULL terminated C strings.  The end of the array must
               be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
-              array of tokens).  
+              array of tokens).
             - arg1_length > 0
             - arg2_length > 0
             - The arg indices reference valid elements of the tokens array.  That is,
@@ -728,7 +762,7 @@ extern "C"
               this function tells the trainer that the given tokens and argument
               combination is not a binary relation we are trying to learn.  The argument
               indices have the same interpretation as they do for
-              mitie_add_positive_binary_relation(). 
+              mitie_add_positive_binary_relation().
             - mitie_binary_relation_trainer_num_negative_examples(trainer) is incremented by 1.
             - returns 0 on success and a non-zero value on failure.  Failure might
               happen if we run out of memory.
@@ -743,7 +777,7 @@ extern "C"
             - trainer != NULL
             - beta >= 0
         ensures
-            - mitie_binary_relation_trainer_get_beta(trainer) == beta 
+            - mitie_binary_relation_trainer_get_beta(trainer) == beta
     !*/
 
     MITIE_EXPORT double mitie_binary_relation_trainer_get_beta (
@@ -768,7 +802,7 @@ extern "C"
 
     MITIE_EXPORT void mitie_binary_relation_trainer_set_num_threads (
         mitie_binary_relation_trainer* trainer,
-        unsigned long num_threads 
+        unsigned long num_threads
     );
     /*!
         requires
@@ -804,6 +838,129 @@ extern "C"
             - The returned object MUST BE FREED by a call to mitie_free().
             - returns NULL if the object could not be created.
     !*/
+// ----------------------------------------------------------------------------------------
+
+    typedef struct mitie_text_categorizer_trainer mitie_text_categorizer_trainer;
+
+
+    MITIE_EXPORT mitie_text_categorizer_trainer* mitie_create_text_categorizer_trainer (
+        const char* filename
+    );
+    /*!
+        requires
+            - filename == a valid pointer to a NULL terminated C string
+        ensures
+            - Creates a text_categorizer trainer object and returns a pointer to it.
+            - filename should contain the name of a saved total_word_feature_extractor, as
+              created by the wordrep tool's -e option (see the MITIE/tools/wordrep folder).
+            - The returned object MUST BE FREED by a call to mitie_free().
+            - returns NULL if the object could not be created.
+            - calling mitie_text_categorizer_trainer_get_beta() on the returned pointer returns 0.5.
+              That is, the default beta value is 0.5.
+            - calling mitie_text_categorizer_trainer_get_num_threads() on the returned pointer returns
+              4.  That is, the default number of threads to use is 4.
+            - calling mitie_text_categorizer_trainer_size() on the returned pointer returns 0.
+              That is, initially there are no training instances in the trainer.
+    !*/
+
+    MITIE_EXPORT unsigned long mitie_text_categorizer_trainer_size (
+        const mitie_text_categorizer_trainer* trainer
+    );
+    /*!
+        requires
+            - trainer != NULL
+        ensures
+            - returns the number of training instances in the given trainer object.
+    !*/
+
+
+    MITIE_EXPORT void mitie_text_categorizer_trainer_set_beta (
+        mitie_text_categorizer_trainer* trainer,
+        double beta
+    );
+    /*!
+        requires
+            - trainer != NULL
+            - beta >= 0
+        ensures
+            - mitie_text_categorizer_trainer_get_beta(trainer) == beta
+    !*/
+
+    MITIE_EXPORT double mitie_text_categorizer_trainer_get_beta (
+        const mitie_text_categorizer_trainer* trainer
+    );
+    /*!
+        requires
+            - trainer != NULL
+        ensures
+            - returns the trainer's beta parameter.  This parameter controls the trade-off
+              between trying to avoid false alarms but also detecting everything.
+              Different values of beta have the following interpretations:
+                - beta < 1 indicates that you care more about avoiding false alarms than
+                  missing detections.  The smaller you make beta the more the trainer will
+                  try to avoid false alarms.
+                - beta == 1 indicates that you don't have a preference between avoiding
+                  false alarms or not missing detections.  That is, you care about these
+                  two things equally.
+                - beta > 1 indicates that care more about not missing detections than
+                  avoiding false alarms.
+    !*/
+
+    MITIE_EXPORT void mitie_text_categorizer_trainer_set_num_threads (
+        mitie_text_categorizer_trainer* trainer,
+        unsigned long num_threads
+    );
+    /*!
+        requires
+            - trainer != NULL
+        ensures
+            - mitie_text_categorizer_trainer_get_num_threads(trainer) == num_threads
+    !*/
+
+    MITIE_EXPORT unsigned long mitie_text_categorizer_trainer_get_num_threads (
+        const mitie_text_categorizer_trainer* trainer
+    );
+    /*!
+        requires
+            - trainer != NULL
+        ensures
+            - returns the number of threads the trainer will use when
+              mitie_train_named_entity_extractor() is called.  You should set this equal to
+              the number of available CPU cores for maximum training speed.
+    !*/
+
+    MITIE_EXPORT int mitie_add_text_categorizer_labeled_text (
+        mitie_text_categorizer_trainer* trainer,
+        char** tokens,
+        const char* label
+    );
+    /*!
+        requires
+            - trainer != NULL
+            - instance != NULL
+        ensures
+            - Adds the given training example to the trainer object.
+            - mitie_text_categorizer_trainer_size(trainer) is incremented by 1.
+            - returns 0 on success and a non-zero value on failure.  Failure might be
+              caused by running out of memory.
+    !*/
+
+    MITIE_EXPORT mitie_text_categorizer* mitie_train_text_categorizer (
+        const mitie_text_categorizer_trainer* trainer
+    );
+    /*!
+        requires
+            - trainer != NULL
+            - mitie_binary_relation_trainer_num_positive_examples(trainer) > 0
+            - mitie_binary_relation_trainer_num_negative_examples(trainer) > 0
+        ensures
+            - Runs the binary relation training process based on the training data in the
+              given trainer.  Once finished, it returns the resulting binary relation
+              detector object.
+            - The returned object MUST BE FREED by a call to mitie_free().
+            - returns NULL if the object could not be created.
+    !*/
+
 
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
@@ -813,4 +970,3 @@ extern "C"
 #endif
 
 #endif // MITLL_MITIe_H_
-

--- a/mitielib/include/mitie.h
+++ b/mitielib/include/mitie.h
@@ -406,11 +406,17 @@ extern "C"
     /*!
         requires            
             - tcat_ != NULL
-            - tokens != NULL
-            - text_tag != NULL
+            - tokens == An array of NULL terminated C strings.  The end of the array must
+              be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
+              array of tokens). 
+            - text_tag != NULL  
             - text_score != NULL        
         ensures
+          - this function uses a trained text_categorizer to predict the category of a text,
+            represented by an array of tokens, where each token is one word. The category is
+            represented by its name (a string).  
           - returns 0 upon success and a non-zero value on failure.  
+          - text_tag and text_score MUST BE FREED by a call to mitie_free().
           - if (this function returns 0) then
               - **text_tag == the predicted category to which this text belongs 
                  (selected from the set of categories tcat_ knows about)
@@ -915,9 +921,9 @@ extern "C"
             - trainer != NULL
         ensures
             - returns the trainer's beta parameter.  This parameter controls the trade-off
-              between trying to avoid false alarms but also detecting everything.
-              Different values of beta have the following interpretations:
-              // TODO document interpretations of beta parameter
+              between precision and recall in measuring the accuracy of the classifier.
+              Beta has the interpretation that we attach beta times as much importance to
+              recall as precision. Set to 1 if these are equally important.               
     !*/
 
     MITIE_EXPORT void mitie_text_categorizer_trainer_set_num_threads (
@@ -950,10 +956,14 @@ extern "C"
     );
     /*!
         requires
-            - tokens != NULL
-            - label != NULL
+            - tokens == An array of NULL terminated C strings.  The end of the array must
+              be indicated by a NULL value (i.e. exactly how mitie_tokenize() defines an
+              array of tokens).
+            - label == a NULL terminated C string.
         ensures
-            - Adds the given training example to the trainer object.
+            - Adds the given training example to the trainer object. The training example
+              consists of a set of tokens (the words in a text) and a label (the name of 
+              the category to which this text belongs). 
             - mitie_text_categorizer_trainer_size(trainer) is incremented by 1.
             - returns 0 on success and a non-zero value on failure.  Failure might be
               caused by running out of memory.

--- a/mitielib/mitie.py
+++ b/mitielib/mitie.py
@@ -588,7 +588,7 @@ _f.mitie_train_text_categorizer.restype = ctypes.c_void_p
 _f.mitie_train_text_categorizer.argtypes = ctypes.c_void_p,
 
 _f.mitie_categorize_text.restype = ctypes.c_ulong
-_f.mitie_categorize_text.argtypes = ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.POINTER(ctypes.c_char_p)), ctypes.POINTER(ctypes.c_double)  #ctypes.POINTER(ctypes.c_char_p)
+_f.mitie_categorize_text.argtypes = ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.POINTER(ctypes.c_char_p)), ctypes.POINTER(ctypes.c_double) 
 
 
 class text_categorizer:

--- a/mitielib/mitie.py
+++ b/mitielib/mitie.py
@@ -588,7 +588,8 @@ _f.mitie_train_text_categorizer.restype = ctypes.c_void_p
 _f.mitie_train_text_categorizer.argtypes = ctypes.c_void_p,
 
 _f.mitie_categorize_text.restype = ctypes.c_ulong
-_f.mitie_categorize_text.argtypes = ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_char_p), ctypes.POINTER(ctypes.c_double) 
+_f.mitie_categorize_text.argtypes = ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.POINTER(ctypes.c_char_p)), ctypes.POINTER(ctypes.c_double)  #ctypes.POINTER(ctypes.c_char_p)
+#types.POINTER(ctypes.c_sizeof), 
 
 class text_categorizer:
     def __init__(self, filename):
@@ -620,16 +621,13 @@ class text_categorizer:
         and if this number is > 0 then the relation detector is indicating that the input relation
         is a true instance of the type of relation this object detects."""
         score = ctypes.c_double()
-        label = ctypes.c_char_p() 
-        #label1 = ctypes.cast(ctypes.create_string_buffer(50),ctypes.c_char_p)
+        label = ctypes.POINTER(ctypes.c_char_p)()
         ctokens = python_to_mitie_str_array(tokens)
         if (_f.mitie_categorize_text(self.__obj, ctokens, ctypes.byref(label), ctypes.byref(score)) != 0):
             raise Exception("Unable to classify text.")
         
-        print(score)
-        print(label)
-
-        return label, score 
+        label = ctypes.cast(label,ctypes.c_char_p)
+        return label.value, score.value 
 
 class text_categorizer_trainer(object):
     def __init__(self, filename):

--- a/mitielib/mitie.py
+++ b/mitielib/mitie.py
@@ -613,7 +613,7 @@ class text_categorizer:
 
     
     def __call__(self, tokens):
-        """Categorise a piece of text. The input should have been produced by 
+        """Categorise a piece of text. The input tokens should have been produced by 
         tokenize().  This function returns a predicted label and a confidence score."""
         score = ctypes.c_double()
         label = ctypes.POINTER(ctypes.c_char_p)()
@@ -622,7 +622,10 @@ class text_categorizer:
             raise Exception("Unable to classify text.")
         
         label = ctypes.cast(label,ctypes.c_char_p)
-        return label.value, score.value 
+        _label, _score = label.value, score.value
+        _f.mitie_free(label)
+        
+        return  _label, _score
 
 class text_categorizer_trainer(object):
     def __init__(self, filename):

--- a/mitielib/mitie.py
+++ b/mitielib/mitie.py
@@ -14,8 +14,8 @@ except NameError:  # Py3
 # Load the mitie shared library.  We will look in a few places to see if we can find it.
 # What we do depends on our platform
 parent = os.path.dirname(os.path.realpath(__file__))
-if os.name == 'nt': 
-    #if on windows just look in the same folder as the mitie.py file and also in any 
+if os.name == 'nt':
+    #if on windows just look in the same folder as the mitie.py file and also in any
     #subfolders that might have the appropriate 32 or 64 bit dlls, whichever is right for
     #the version of python we are using.
     arch = platform.architecture()
@@ -38,9 +38,9 @@ else:
     times = [(_last_modified_time(f),f) for f in files]
     most_recent = max(times, key=lambda x:x[0])[1]
     _f = ctypes.CDLL(most_recent)
-    
 
-    
+
+
 
 _f.mitie_free.restype = None
 _f.mitie_free.argtypes = ctypes.c_void_p,
@@ -92,7 +92,7 @@ def _get_windowed_range(tokens, arg1, arg2):
     begin = min(min(arg1), min(arg2))
     end   = max(max(arg1), max(arg2))+1
     if (begin > winsize):
-        begin -= winsize 
+        begin -= winsize
     else:
         begin = 0
     end = min(end+winsize, len(tokens))
@@ -101,8 +101,8 @@ def _get_windowed_range(tokens, arg1, arg2):
 
 
 def python_to_mitie_str_array(tokens, r = None):
-    """Convert from a Python list of strings into MITIE's NULL terminated char** array type.  
-    Note that the memory returned by this object is managed by Python and doesn't need to be 
+    """Convert from a Python list of strings into MITIE's NULL terminated char** array type.
+    Note that the memory returned by this object is managed by Python and doesn't need to be
     freed by the user.
 
     r should be a range that indicates which part of tokens to convert.  If r is not given
@@ -130,7 +130,7 @@ def load_entire_file(filename):
     x = _f.mitie_load_entire_file(filename)
     if (x == None):
         raise Exception("Unable to load file " + filename)
-    res = ctypes.string_at(x) 
+    res = ctypes.string_at(x)
     _f.mitie_free(x)
     return res
 
@@ -197,7 +197,7 @@ class named_entity_extractor:
 
     def save_to_disk(self, filename):
         """Save this object to disk.  You recall it from disk with the following Python
-        code: 
+        code:
             ner = named_entity_extractor(filename)"""
         if (_f.mitie_save_named_entity_extractor(filename, self.__obj) != 0):
             raise Exception("Unable to save named_entity_extractor to the file " + filename);
@@ -250,10 +250,10 @@ class named_entity_extractor:
 ####################################################################################################
 
 _f.mitie_load_binary_relation_detector.restype = ctypes.c_void_p
-_f.mitie_load_binary_relation_detector.argtypes = ctypes.c_char_p, 
+_f.mitie_load_binary_relation_detector.argtypes = ctypes.c_char_p,
 
 _f.mitie_binary_relation_detector_name_string.restype = ctypes.c_char_p
-_f.mitie_binary_relation_detector_name_string.argtypes = ctypes.c_void_p, 
+_f.mitie_binary_relation_detector_name_string.argtypes = ctypes.c_void_p,
 
 _f.mitie_classify_binary_relation.restype = ctypes.c_int
 _f.mitie_classify_binary_relation.argtypes = ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_double)
@@ -264,7 +264,7 @@ _f.mitie_save_binary_relation_detector.argtypes = ctypes.c_char_p, ctypes.c_void
 
 class binary_relation:
     def __init__(self, obj):
-        self.__obj =  obj 
+        self.__obj =  obj
         self.__mitie_free = _f.mitie_free
 
     @property
@@ -293,7 +293,7 @@ class binary_relation_detector:
 
     def save_to_disk(self, filename):
         """Save this object to disk.  You recall it from disk with the following Python
-        code: 
+        code:
             ner = binary_relation_detector(filename)"""
         if (_f.mitie_save_binary_relation_detector(filename, self.__obj) != 0):
             raise Exception("Unable to save binary_relation_detector to the file " + filename);
@@ -307,9 +307,9 @@ class binary_relation_detector:
     @property
     def name_string(self):
         return _f.mitie_binary_relation_detector_name_string(self.__obj)
-    
+
     def __call__(self, relation):
-        """Classify a relation object.  The input should have been produced by 
+        """Classify a relation object.  The input should have been produced by
         named_entity_extractor.extract_binary_relation().  This function returns a classification score
         and if this number is > 0 then the relation detector is indicating that the input relation
         is a true instance of the type of relation this object detects."""
@@ -326,7 +326,7 @@ _f.mitie_add_ner_training_entity.restype = ctypes.c_int
 _f.mitie_add_ner_training_entity.argtypes = ctypes.c_void_p, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_char_p
 
 _f.mitie_add_ner_training_instance.restype = ctypes.c_int
-_f.mitie_add_ner_training_instance.argtypes = ctypes.c_void_p, ctypes.c_void_p 
+_f.mitie_add_ner_training_instance.argtypes = ctypes.c_void_p, ctypes.c_void_p
 
 _f.mitie_create_ner_trainer.restype = ctypes.c_void_p
 _f.mitie_create_ner_trainer.argtypes = ctypes.c_char_p,
@@ -396,7 +396,7 @@ class ner_training_instance:
             raise Exception("Invalid range given to ner_training_instance.overlaps_any_entity().  It overlaps an entity given to a previous call to add_entity().")
         if (_f.mitie_add_ner_training_entity(self.__obj, min(range), len(range), label) != 0):
             raise Exception("Unable to add entity to training instance.  Probably ran out of RAM.");
-        
+
 
 class ner_trainer(object):
     def __init__(self, filename):
@@ -407,7 +407,7 @@ class ner_trainer(object):
 
     def __del__(self):
         self.__mitie_free(self.__obj)
-    
+
     @property
     def size(self):
         return _f.mitie_ner_trainer_size(self.__obj)
@@ -425,7 +425,7 @@ class ner_trainer(object):
         if (value < 0):
             raise Exception("Invalid beta value given.  beta can't be negative.")
         _f.mitie_ner_trainer_set_beta(self.__obj, value)
-    
+
     @property
     def num_threads(self):
         return _f.mitie_ner_trainer_get_num_threads(self.__obj)
@@ -433,7 +433,7 @@ class ner_trainer(object):
     @num_threads.setter
     def num_threads(self, value):
         _f.mitie_ner_trainer_set_num_threads(self.__obj, value)
-    
+
     def train(self):
         if (self.size == 0):
             raise Exception("You can't call train() on an empty trainer.")
@@ -537,7 +537,7 @@ class binary_relation_detector_trainer(object):
         if (value < 0):
             raise Exception("Invalid beta value given.  beta can't be negative.")
         _f.mitie_binary_relation_trainer_set_beta(self.__obj, value)
-    
+
     @property
     def num_threads(self):
         return _f.mitie_binary_relation_trainer_get_num_threads(self.__obj)
@@ -545,7 +545,7 @@ class binary_relation_detector_trainer(object):
     @num_threads.setter
     def num_threads(self, value):
         _f.mitie_binary_relation_trainer_set_num_threads(self.__obj, value)
-    
+
     def train(self):
         if (self.num_positive_examples == 0 or self.num_negative_examples == 0):
             raise Exception("You must give both positive and negative training examples before you call train().")
@@ -555,4 +555,87 @@ class binary_relation_detector_trainer(object):
             raise Exception("Unable to create binary_relation_detector.  Probably ran out of RAM")
         return binary_relation_detector(obj)
 
+##############################################################################
 
+_f.mitie_add_text_categorizer_labeled_text.restype = ctypes.c_int
+_f.mitie_add_text_categorizer_labeled_text.argtypes = ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p
+
+_f.mitie_load_text_categorizer.restype = ctypes.c_void_p
+_f.mitie_load_text_categorizer.argtypes = ctypes.c_char_p,
+
+_f.mitie_text_categorizer_trainer_get_beta.restype = ctypes.c_double
+_f.mitie_text_categorizer_trainer_get_beta.argtypes = ctypes.c_void_p,
+
+_f.mitie_text_categorizer_trainer_get_num_threads.restype = ctypes.c_ulong
+_f.mitie_text_categorizer_trainer_get_num_threads.argtypes = ctypes.c_void_p,
+
+_f.mitie_text_categorizer_trainer_set_beta.restype = None
+_f.mitie_text_categorizer_trainer_set_beta.argtypes = ctypes.c_void_p, ctypes.c_double
+
+_f.mitie_text_categorizer_trainer_set_num_threads.restype = None
+_f.mitie_text_categorizer_trainer_set_num_threads.argtypes = ctypes.c_void_p, ctypes.c_ulong
+
+#_f.mitie_text_categorizer_trainer_size.restype = ctypes.c_ulong
+#_f.mitie_text_categorizer_trainer_size.argtypes = ctypes.c_void_p,
+
+#_f.mitie_text_categorizer_trainer_count_of_least_common_label = ctypes.c_ulong#
+#_f.mitie_text_categorizer_trainer_count_of_least_common_label = ctypes.c_void_p,
+
+_f.mitie_train_text_categorizer.restype = ctypes.c_void_p
+_f.mitie_train_text_categorizer.argtypes = ctypes.c_void_p,
+
+
+class text_categorizer_trainer(object):
+    def __init__(self, filename):
+        self.__obj = _f.mitie_create_text_categorizer_trainer(filename)
+        self.__mitie_free = _f.mitie_free
+        if (self.__obj == None):
+            raise Exception("Unable to create text_categorizer_trainer based on " + filename)
+
+    def __del__(self):
+        self.__mitie_free(self.__obj)
+
+    #@property
+    #def size(self):
+    #    return _f.mitie_text_categorizer_trainer_size(self.__obj)
+
+    #def count_of_least_common_label(self):
+    #    return _f.mitie_text_categorizer_trainer_count_of_least_common_label(self.__obj)
+
+    #def get_all_labels(self):
+    #    return _f.mitie_text_categorizer_trainer_get_all_labels(self.__obj)
+
+    #def get_label_id(self,str):
+    #    return _f.mitie_text_categorizer_trainer_get_label_id(str)
+
+    def add_labeled_text(self, tokens, label):
+        ctokens = python_to_mitie_str_array(tokens)
+        if (_f.mitie_add_text_categorizer_labeled_text(self.__obj, ctokens, label) != 0):
+            raise Exception("Unable to add entity to training instance.  Probably ran out of RAM.");
+
+    @property
+    def beta(self):
+        return _f.mitie_text_categorizer_trainer_get_beta(self.__obj)
+
+    @beta.setter
+    def beta(self, value):
+        if (value < 0):
+            raise Exception("Invalid beta value given.  beta can't be negative.")
+        _f.mitie_text_categorizer_trainer_set_beta(self.__obj, value)
+
+    @property
+    def num_threads(self):
+        return _f.mitie_text_categorizer_trainer_get_num_threads(self.__obj)
+
+    @num_threads.setter
+    def num_threads(self, value):
+        _f.mitie_text_categorizer_trainer_set_num_threads(self.__obj, value)
+
+    def train(self):
+        #if (self.size == 0):
+        #    raise Exception("You can't call train() on an empty trainer.")
+        # Make the type be a c_void_p so the named_entity_extractor constructor will know what to do.
+        obj = ctypes.c_void_p(_f.mitie_train_text_categorizer(self.__obj))
+        if (obj == None):
+            raise Exception("Unable to create text_categorizer.  Probably ran out of RAM")
+        return text_categorizer(obj)

--- a/mitielib/mitie.py
+++ b/mitielib/mitie.py
@@ -14,8 +14,8 @@ except NameError:  # Py3
 # Load the mitie shared library.  We will look in a few places to see if we can find it.
 # What we do depends on our platform
 parent = os.path.dirname(os.path.realpath(__file__))
-if os.name == 'nt':
-    #if on windows just look in the same folder as the mitie.py file and also in any
+if os.name == 'nt': 
+    #if on windows just look in the same folder as the mitie.py file and also in any 
     #subfolders that might have the appropriate 32 or 64 bit dlls, whichever is right for
     #the version of python we are using.
     arch = platform.architecture()
@@ -38,9 +38,9 @@ else:
     times = [(_last_modified_time(f),f) for f in files]
     most_recent = max(times, key=lambda x:x[0])[1]
     _f = ctypes.CDLL(most_recent)
+    
 
-
-
+    
 
 _f.mitie_free.restype = None
 _f.mitie_free.argtypes = ctypes.c_void_p,
@@ -92,7 +92,7 @@ def _get_windowed_range(tokens, arg1, arg2):
     begin = min(min(arg1), min(arg2))
     end   = max(max(arg1), max(arg2))+1
     if (begin > winsize):
-        begin -= winsize
+        begin -= winsize 
     else:
         begin = 0
     end = min(end+winsize, len(tokens))
@@ -101,8 +101,8 @@ def _get_windowed_range(tokens, arg1, arg2):
 
 
 def python_to_mitie_str_array(tokens, r = None):
-    """Convert from a Python list of strings into MITIE's NULL terminated char** array type.
-    Note that the memory returned by this object is managed by Python and doesn't need to be
+    """Convert from a Python list of strings into MITIE's NULL terminated char** array type.  
+    Note that the memory returned by this object is managed by Python and doesn't need to be 
     freed by the user.
 
     r should be a range that indicates which part of tokens to convert.  If r is not given
@@ -130,7 +130,7 @@ def load_entire_file(filename):
     x = _f.mitie_load_entire_file(filename)
     if (x == None):
         raise Exception("Unable to load file " + filename)
-    res = ctypes.string_at(x)
+    res = ctypes.string_at(x) 
     _f.mitie_free(x)
     return res
 
@@ -197,7 +197,7 @@ class named_entity_extractor:
 
     def save_to_disk(self, filename):
         """Save this object to disk.  You recall it from disk with the following Python
-        code:
+        code: 
             ner = named_entity_extractor(filename)"""
         if (_f.mitie_save_named_entity_extractor(filename, self.__obj) != 0):
             raise Exception("Unable to save named_entity_extractor to the file " + filename);
@@ -250,10 +250,10 @@ class named_entity_extractor:
 ####################################################################################################
 
 _f.mitie_load_binary_relation_detector.restype = ctypes.c_void_p
-_f.mitie_load_binary_relation_detector.argtypes = ctypes.c_char_p,
+_f.mitie_load_binary_relation_detector.argtypes = ctypes.c_char_p, 
 
 _f.mitie_binary_relation_detector_name_string.restype = ctypes.c_char_p
-_f.mitie_binary_relation_detector_name_string.argtypes = ctypes.c_void_p,
+_f.mitie_binary_relation_detector_name_string.argtypes = ctypes.c_void_p, 
 
 _f.mitie_classify_binary_relation.restype = ctypes.c_int
 _f.mitie_classify_binary_relation.argtypes = ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_double)
@@ -264,7 +264,7 @@ _f.mitie_save_binary_relation_detector.argtypes = ctypes.c_char_p, ctypes.c_void
 
 class binary_relation:
     def __init__(self, obj):
-        self.__obj =  obj
+        self.__obj =  obj 
         self.__mitie_free = _f.mitie_free
 
     @property
@@ -293,7 +293,7 @@ class binary_relation_detector:
 
     def save_to_disk(self, filename):
         """Save this object to disk.  You recall it from disk with the following Python
-        code:
+        code: 
             ner = binary_relation_detector(filename)"""
         if (_f.mitie_save_binary_relation_detector(filename, self.__obj) != 0):
             raise Exception("Unable to save binary_relation_detector to the file " + filename);
@@ -307,9 +307,9 @@ class binary_relation_detector:
     @property
     def name_string(self):
         return _f.mitie_binary_relation_detector_name_string(self.__obj)
-
+    
     def __call__(self, relation):
-        """Classify a relation object.  The input should have been produced by
+        """Classify a relation object.  The input should have been produced by 
         named_entity_extractor.extract_binary_relation().  This function returns a classification score
         and if this number is > 0 then the relation detector is indicating that the input relation
         is a true instance of the type of relation this object detects."""
@@ -326,7 +326,7 @@ _f.mitie_add_ner_training_entity.restype = ctypes.c_int
 _f.mitie_add_ner_training_entity.argtypes = ctypes.c_void_p, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_char_p
 
 _f.mitie_add_ner_training_instance.restype = ctypes.c_int
-_f.mitie_add_ner_training_instance.argtypes = ctypes.c_void_p, ctypes.c_void_p
+_f.mitie_add_ner_training_instance.argtypes = ctypes.c_void_p, ctypes.c_void_p 
 
 _f.mitie_create_ner_trainer.restype = ctypes.c_void_p
 _f.mitie_create_ner_trainer.argtypes = ctypes.c_char_p,
@@ -396,7 +396,7 @@ class ner_training_instance:
             raise Exception("Invalid range given to ner_training_instance.overlaps_any_entity().  It overlaps an entity given to a previous call to add_entity().")
         if (_f.mitie_add_ner_training_entity(self.__obj, min(range), len(range), label) != 0):
             raise Exception("Unable to add entity to training instance.  Probably ran out of RAM.");
-
+        
 
 class ner_trainer(object):
     def __init__(self, filename):
@@ -407,7 +407,7 @@ class ner_trainer(object):
 
     def __del__(self):
         self.__mitie_free(self.__obj)
-
+    
     @property
     def size(self):
         return _f.mitie_ner_trainer_size(self.__obj)
@@ -425,7 +425,7 @@ class ner_trainer(object):
         if (value < 0):
             raise Exception("Invalid beta value given.  beta can't be negative.")
         _f.mitie_ner_trainer_set_beta(self.__obj, value)
-
+    
     @property
     def num_threads(self):
         return _f.mitie_ner_trainer_get_num_threads(self.__obj)
@@ -433,7 +433,7 @@ class ner_trainer(object):
     @num_threads.setter
     def num_threads(self, value):
         _f.mitie_ner_trainer_set_num_threads(self.__obj, value)
-
+    
     def train(self):
         if (self.size == 0):
             raise Exception("You can't call train() on an empty trainer.")
@@ -537,7 +537,7 @@ class binary_relation_detector_trainer(object):
         if (value < 0):
             raise Exception("Invalid beta value given.  beta can't be negative.")
         _f.mitie_binary_relation_trainer_set_beta(self.__obj, value)
-
+    
     @property
     def num_threads(self):
         return _f.mitie_binary_relation_trainer_get_num_threads(self.__obj)
@@ -545,7 +545,7 @@ class binary_relation_detector_trainer(object):
     @num_threads.setter
     def num_threads(self, value):
         _f.mitie_binary_relation_trainer_set_num_threads(self.__obj, value)
-
+    
     def train(self):
         if (self.num_positive_examples == 0 or self.num_negative_examples == 0):
             raise Exception("You must give both positive and negative training examples before you call train().")
@@ -577,9 +577,6 @@ _f.mitie_text_categorizer_trainer_set_num_threads.argtypes = ctypes.c_void_p, ct
 
 #_f.mitie_text_categorizer_trainer_size.restype = ctypes.c_ulong
 #_f.mitie_text_categorizer_trainer_size.argtypes = ctypes.c_void_p,
-
-#_f.mitie_text_categorizer_trainer_count_of_least_common_label = ctypes.c_ulong#
-#_f.mitie_text_categorizer_trainer_count_of_least_common_label = ctypes.c_void_p,
 
 _f.mitie_train_text_categorizer.restype = ctypes.c_void_p
 _f.mitie_train_text_categorizer.argtypes = ctypes.c_void_p,
@@ -639,3 +636,4 @@ class text_categorizer_trainer(object):
         if (obj == None):
             raise Exception("Unable to create text_categorizer.  Probably ran out of RAM")
         return text_categorizer(obj)
+

--- a/mitielib/mitie.py
+++ b/mitielib/mitie.py
@@ -575,8 +575,8 @@ _f.mitie_text_categorizer_trainer_set_beta.argtypes = ctypes.c_void_p, ctypes.c_
 _f.mitie_text_categorizer_trainer_set_num_threads.restype = None
 _f.mitie_text_categorizer_trainer_set_num_threads.argtypes = ctypes.c_void_p, ctypes.c_ulong
 
-#_f.mitie_text_categorizer_trainer_size.restype = ctypes.c_ulong
-#_f.mitie_text_categorizer_trainer_size.argtypes = ctypes.c_void_p,
+_f.mitie_text_categorizer_trainer_size.restype = ctypes.c_ulong
+_f.mitie_text_categorizer_trainer_size.argtypes = ctypes.c_void_p,
 
 _f.mitie_train_text_categorizer.restype = ctypes.c_void_p
 _f.mitie_train_text_categorizer.argtypes = ctypes.c_void_p,
@@ -592,18 +592,9 @@ class text_categorizer_trainer(object):
     def __del__(self):
         self.__mitie_free(self.__obj)
 
-    #@property
-    #def size(self):
-    #    return _f.mitie_text_categorizer_trainer_size(self.__obj)
-
-    #def count_of_least_common_label(self):
-    #    return _f.mitie_text_categorizer_trainer_count_of_least_common_label(self.__obj)
-
-    #def get_all_labels(self):
-    #    return _f.mitie_text_categorizer_trainer_get_all_labels(self.__obj)
-
-    #def get_label_id(self,str):
-    #    return _f.mitie_text_categorizer_trainer_get_label_id(str)
+    @property
+    def size(self):
+        return _f.mitie_text_categorizer_trainer_size(self.__obj)
 
     def add_labeled_text(self, tokens, label):
         ctokens = python_to_mitie_str_array(tokens)

--- a/mitielib/src/mitie.cpp
+++ b/mitielib/src/mitie.cpp
@@ -716,26 +716,36 @@ extern "C"
          double* text_score
      )
      {
-         assert(text_tag);
-         assert(text_score);
+         try
+         {       
+             assert(text_tag);
+             assert(text_score);
 
-         string tag;
-         double score;
-         std::vector<std::string> words;
+             string tag;
+             double score;
+             std::vector<std::string> words;
 
-         while(*tokens)
-             words.push_back(*tokens++);
-          
-         checked_cast<text_categorizer>(tcat_).predict(words,tag,score);
+             while(*tokens)
+                 words.push_back(*tokens++);
+              
+             checked_cast<text_categorizer>(tcat_).predict(words,tag,score);
 
-         char * writable = new char[tag.size() + 1];
-         std::copy(tag.begin(), tag.end(), writable);
-         writable[tag.size()] = '\0';
-         
-         *text_tag = writable;               
-         *text_score = score;
-                  
-         return 0; //TODO try/catch block
+             char * writable = new char[tag.size() + 1];
+             std::copy(tag.begin(), tag.end(), writable);
+             writable[tag.size()] = '\0';
+             
+             *text_tag = writable;               
+             *text_score = score;
+                      
+             return 0; 
+         }
+         catch (...)
+         {
+#ifndef NDEBUG
+             cerr << "Error categorizing text: " << endl;
+#endif
+             return 1;
+         }
      }
      
 // ----------------------------------------------------------------------------------------

--- a/mitielib/src/mitie.cpp
+++ b/mitielib/src/mitie.cpp
@@ -712,21 +712,29 @@ extern "C"
      int mitie_categorize_text (
          const mitie_text_categorizer* tcat_,
          const char** tokens,
-         char* text_tag,
+         char** text_tag,
          double* text_score
      )
      {
          assert(text_tag);
          assert(text_score);
+
          string tag;
          double score;
          std::vector<std::string> words;
+
          while(*tokens)
              words.push_back(*tokens++);
+          
          checked_cast<text_categorizer>(tcat_).predict(words,tag,score);
-         *text_tag = *tag.c_str();
-         *text_score = score;
+
+         char * writable = new char[tag.size() + 1];
+         std::copy(tag.begin(), tag.end(), writable);
+         writable[tag.size()] = '\0';
          
+         *text_tag = writable;               
+         *text_score = score;
+                  
          return 0; //TODO try/catch block
      }
      

--- a/mitielib/src/mitie.cpp
+++ b/mitielib/src/mitie.cpp
@@ -1143,7 +1143,7 @@ extern "C"
       const char* label
     )
     {
-        //assert(tokens);
+        assert(tokens);
         assert(label);
         text_categorizer_trainer& trainer =  checked_cast<text_categorizer_trainer>(trainer_);
         try
@@ -1158,6 +1158,15 @@ extern "C"
         {
             return 1;
         }
+    }
+    
+// ----------------------------------------------------------------------------------------
+
+    unsigned long mitie_text_categorizer_trainer_size (
+        const mitie_text_categorizer_trainer* trainer_
+    )
+    {
+        return checked_cast<text_categorizer_trainer>(trainer_).size();
     }
 
 // ----------------------------------------------------------------------------------------

--- a/mitielib/src/mitie.cpp
+++ b/mitielib/src/mitie.cpp
@@ -708,6 +708,28 @@ extern "C"
              return NULL;
          }
      }
+     
+     int mitie_categorize_text (
+         const mitie_text_categorizer* tcat_,
+         const char** tokens,
+         char* text_tag,
+         double* text_score
+     )
+     {
+         assert(text_tag);
+         assert(text_score);
+         string tag;
+         double score;
+         std::vector<std::string> words;
+         while(*tokens)
+             words.push_back(*tokens++);
+         checked_cast<text_categorizer>(tcat_).predict(words,tag,score);
+         *text_tag = *tag.c_str();
+         *text_score = score;
+         
+         return 0; //TODO try/catch block
+     }
+     
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 //                                      TRAINING ROUTINES
@@ -774,6 +796,34 @@ extern "C"
         }
     }
 
+    int mitie_save_text_categorizer (
+        const char* filename,
+        const mitie_text_categorizer* tcat_
+    )
+    {
+        const text_categorizer& tcat = checked_cast<text_categorizer>(tcat_);
+        assert(filename);
+
+        try
+        {
+            dlib::serialize(filename) << "mitie::text_categorizer" << tcat;
+            return 0;
+        }
+        catch (std::exception& e)
+        {
+#ifndef NDEBUG
+            cerr << "Error saving MITIE model file: " << filename << "\n" << e.what() << endl;
+#endif
+            return 1;
+        }
+        catch (...)
+        {
+#ifndef NDEBUG
+            cerr << "Error saving MITIE model file: " << filename << endl;
+#endif
+            return 1;
+        }
+    }
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 

--- a/mitielib/src/mitie.cpp
+++ b/mitielib/src/mitie.cpp
@@ -730,7 +730,7 @@ extern "C"
               
              checked_cast<text_categorizer>(tcat_).predict(words,tag,score);
 
-             char * writable = new char[tag.size() + 1];
+             char * writable = (char*)allocate_bytes(tag.size()+1);
              std::copy(tag.begin(), tag.end(), writable);
              writable[tag.size()] = '\0';
              
@@ -1207,7 +1207,7 @@ extern "C"
 
     int mitie_add_text_categorizer_labeled_text (
       mitie_text_categorizer_trainer* trainer_,
-      char** tokens,
+      const char** tokens,
       const char* label
     )
     {
@@ -1282,7 +1282,7 @@ extern "C"
       const mitie_text_categorizer_trainer* trainer_
   )
   {
-      //assert(mitie_binary_relation_trainer_num_positive_examples(trainer_) > 0);
+      assert(mitie_text_categorizer_trainer_size(trainer_) > 0);
       const text_categorizer_trainer& trainer =  checked_cast<text_categorizer_trainer>(trainer_);
       try
       {

--- a/mitielib/src/mitie.cpp
+++ b/mitielib/src/mitie.cpp
@@ -19,10 +19,9 @@
 #include <mitie/text_categorizer.h>
 #include <mitie/text_categorizer_trainer.h>
 
-
 using namespace mitie;
 
-namespace
+namespace 
 {
 
     /*
@@ -45,7 +44,7 @@ namespace
         MITIE_NER_TRAINING_INSTANCE,
         MITIE_NER_TRAINER,
         MITIE_TEXT_CATEGORIZER,
-        MITIE_TEXT_CATEGORIZER_TRAINER
+        MITIE_TEXT_CATEGORIZER_TRAINER        
     };
 
     template <typename T>
@@ -62,6 +61,7 @@ namespace
     template <> struct allocatable_types<text_categorizer>              { const static mitie_object_type type = MITIE_TEXT_CATEGORIZER; };
     template <> struct allocatable_types<text_categorizer_trainer>      { const static mitie_object_type type = MITIE_TEXT_CATEGORIZER_TRAINER; };
 
+
 // ----------------------------------------------------------------------------------------
 
     const int min_alignment = 16;
@@ -71,16 +71,15 @@ namespace
     }
 
     template <typename T>
-    T& checked_cast(void* ptr)
+    T& checked_cast(void* ptr) 
     {
         assert(ptr);
-        cout << memory_block_type(ptr) << allocatable_types<T>::type << endl;  
         assert(memory_block_type(ptr) == allocatable_types<T>::type);
         return *static_cast<T*>(ptr);
     }
 
     template <typename T>
-    const T& checked_cast(const void* ptr)
+    const T& checked_cast(const void* ptr) 
     {
         assert(ptr);
         assert(memory_block_type(ptr) == allocatable_types<T>::type);
@@ -336,7 +335,7 @@ extern "C"
 
 
     void mitie_free (
-        void* object
+        void* object 
     )
     {
         if (object == 0)
@@ -373,7 +372,7 @@ extern "C"
                 break;
             case MITIE_TEXT_CATEGORIZER:
                 destroy<text_categorizer>(object);
-                break;
+                break;                
             default:
                 std::cerr << "ERROR, mitie_free() called on non-MITIE object or called twice." << std::endl;
                 assert(false);
@@ -437,7 +436,7 @@ extern "C"
 
     mitie_named_entity_detections* mitie_extract_entities (
         const mitie_named_entity_extractor* ner_,
-        char** tokens
+        char** tokens 
     )
     {
         const named_entity_extractor& ner = checked_cast<named_entity_extractor>(ner_);
@@ -615,7 +614,7 @@ extern "C"
             unsigned long begin = std::min(arg1_start, arg2_start);
             if (begin > window_size)
                 begin -= window_size;
-            else
+            else 
                 begin = 0;
 
             const unsigned long end = std::max(arg1_start+arg1_length, arg2_start+arg2_length)+window_size;
@@ -677,45 +676,38 @@ extern "C"
             return 1;
         }
     }
-
-    // ----------------------------------------------------------------------------------------
-    // ----------------------------------------------------------------------------------------
-    // ----------------------------------------------------------------------------------------
-    // ----------------------------------------------------------------------------------------
-
-
+    
     mitie_text_categorizer* mitie_load_text_categorizer (
-        const char* filename
-    )
-    {
-        assert(filename != NULL);
+         const char* filename
+     )
+     {
+         assert(filename != NULL);
 
-        text_categorizer* impl = 0;
-        try
-        {
-            string classname;
-            impl = allocate<text_categorizer>();
-            dlib::deserialize(filename) >> classname;
-            if (classname != "mitie::text_categorizer")
-                throw dlib::error("This file does not contain a mitie::text_categorizer. Contained: " + classname);
-            dlib::deserialize(filename) >> classname >> *impl;
-            return (mitie_text_categorizer*)impl;
-        }
-        catch(std::exception& e)
-        {
-#ifndef NDEBUG
-            cerr << "Error loading MITIE model file: " << filename << "\n" << e.what() << endl;
-#endif
-            mitie_free(impl);
-            return NULL;
-        }
-        catch(...)
-        {
-            mitie_free(impl);
-            return NULL;
-        }
-    }
-
+         text_categorizer* impl = 0;
+         try
+         {
+             string classname;
+             impl = allocate<text_categorizer>();
+             dlib::deserialize(filename) >> classname;
+             if (classname != "mitie::text_categorizer")
+                 throw dlib::error("This file does not contain a mitie::text_categorizer. Contained: " + classname);
+             dlib::deserialize(filename) >> classname >> *impl;
+             return (mitie_text_categorizer*)impl;
+         }
+         catch(std::exception& e)
+         {
+ #ifndef NDEBUG
+             cerr << "Error loading MITIE model file: " << filename << "\n" << e.what() << endl;
+ #endif
+             mitie_free(impl);
+             return NULL;
+         }
+         catch(...)
+         {
+             mitie_free(impl);
+             return NULL;
+         }
+     }
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 //                                      TRAINING ROUTINES
@@ -755,7 +747,7 @@ extern "C"
 
     int mitie_save_binary_relation_detector (
         const char* filename,
-        const mitie_binary_relation_detector* detector_
+        const mitie_binary_relation_detector* detector_ 
     )
     {
         const binary_relation_detector& detector = checked_cast<binary_relation_detector>(detector_);
@@ -937,7 +929,7 @@ extern "C"
 
     void mitie_ner_trainer_set_num_threads (
         mitie_ner_trainer* trainer_,
-        unsigned long num_threads
+        unsigned long num_threads 
     )
     {
         checked_cast<ner_trainer>(trainer_).set_num_threads(num_threads);
@@ -969,7 +961,7 @@ extern "C"
             return 0;
         }
     }
-
+    
 // ----------------------------------------------------------------------------------------
 
     mitie_binary_relation_trainer* mitie_create_binary_relation_trainer (
@@ -1092,7 +1084,7 @@ extern "C"
 
     void mitie_binary_relation_trainer_set_num_threads (
         mitie_binary_relation_trainer* trainer_,
-        unsigned long num_threads
+        unsigned long num_threads 
     )
     {
         checked_cast<binary_relation_detector_trainer>(trainer_).set_num_threads(num_threads);
@@ -1125,7 +1117,6 @@ extern "C"
             return NULL;
         }
     }
-
 // ----------------------------------------------------------------------------------------
 
     mitie_text_categorizer_trainer* mitie_create_text_categorizer_trainer (
@@ -1226,4 +1217,6 @@ extern "C"
       }
   }
 
+
 }
+


### PR DESCRIPTION
Ok so not done yet but wanted to start discussion. Have quite a few editor artefacts looking at the changes here. 

Currently if I try to call the `add` function on an instance of the text_categorizer_trainer I get an error thrown in the `checked_cast` method in `mitie.cpp` (see  examples/python/train_text_categorizer.py )