### PR TITLE
Fix/issue125

### DIFF
--- a/examples/java/NerExample.java
+++ b/examples/java/NerExample.java
@@ -16,7 +16,14 @@ public class NerExample
         // variable if on a UNIX system.  This example program comes with both .bat and .sh
         // scripts that show how to do this on any system.
 
-
+        try
+        {
+            System.loadLibrary("javamitie");
+        }
+        catch (UnsatisfiedLinkError e)
+        {
+            System.err.println("java.library.path=" + System.getProperty("java.library.path"));
+        }
 
         System.out.println("loading NER model...");
         NamedEntityExtractor ner = new NamedEntityExtractor("../../MITIE-models/english/ner_model.dat");

--- a/examples/java/run_ner.sh
+++ b/examples/java/run_ner.sh
@@ -7,4 +7,4 @@ export CLASSPATH=../../mitielib/javamitie.jar:.
 
 javac NerExample.java
 
-java NerExample 
+java -Djava.library.path="../../mitielib/" NerExample

--- a/examples/java/run_train_ner.sh
+++ b/examples/java/run_train_ner.sh
@@ -7,4 +7,4 @@ export CLASSPATH=../../mitielib/javamitie.jar:.
 
 javac TrainNerExample.java
 
-java TrainNerExample 
+java -Djava.library.path="../../mitielib/" TrainNerExample 

--- a/examples/java/run_train_separate_doc_categorizer.sh
+++ b/examples/java/run_train_separate_doc_categorizer.sh
@@ -7,4 +7,4 @@ export CLASSPATH=../../mitielib/javamitie.jar:.
 
 javac TrainSeparateDocCategorizerExample.java
 
-java TrainSeparateDocCategorizerExample
+java -Djava.library.path="../../mitielib/" TrainSeparateDocCategorizerExample

--- a/examples/java/run_train_separate_ner.sh
+++ b/examples/java/run_train_separate_ner.sh
@@ -7,4 +7,4 @@ export CLASSPATH=../../mitielib/javamitie.jar:.
 
 javac TrainSeparateNerExample.java
 
-java TrainSeparateNerExample
+java -Djava.library.path="../../mitielib/" TrainSeparateNerExample


### PR DESCRIPTION
This closes mit-nlp/MITIE#125 and should close mit-nlp/MITIE#79. It sets the path to the native code library with a command line argument, because setting `DYLD_LIBRARY_PATH` may not work on some recent versions of osx.