### PR TITLE
Updated README to add link to MitieNetCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ as well as tools for training custom extractors and relation detectors.
 
 MITIE is built on top of [dlib](http://dlib.net), a high-performance machine-learning library[1], MITIE makes use of several state-of-the-art techniques including the use of distributional word embeddings[2] and Structural Support Vector Machines[3].  MITIE offers several pre-trained models providing varying levels of support for both English, Spanish, and German trained using a variety of linguistic resources (e.g., CoNLL 2003, ACE, [Wikipedia, Freebase](https://github.com/mit-nlp/MITIE/releases/download/v0.4/freebase_wikipedia_binary_relation_training_data_v1.0.tar.bz2), and Gigaword). The core MITIE software is written in C++, but bindings for several other software languages including Python, R, Java, C, and MATLAB allow a user to quickly integrate MITIE into his/her own applications.
 
-Outside projects have created API bindings for [OCaml](https://github.com/travisbrady/omitie) and 
-[.NET](https://github.com/BayardRock/MITIE-Dot-Net).  There is also an [interactive tool](https://github.com/Sotera/mitie-trainer) for labeling data and training MITIE.
+Outside projects have created API bindings for [OCaml](https://github.com/travisbrady/omitie), 
+[.NET](https://github.com/BayardRock/MITIE-Dot-Net), and [.NET Core](https://github.com/slamj1/MitieNetCore). There is also an [interactive tool](https://github.com/Sotera/mitie-trainer) for labeling data and training MITIE.
 
 # Using MITIE
 


### PR DESCRIPTION
Added some verbiage and link in README to MitieNetCore, a .NET Core bindings library with complete API coverage as per mitie.h.