### PR TITLE
CMake VS include file path.

### DIFF
--- a/mitielib/cmake
+++ b/mitielib/cmake
@@ -3,14 +3,13 @@ set(DLIB_LINK_WITH_LIBPNG OFF CACHE STRING "not needed by MITIE" FORCE)
 set(DLIB_LINK_WITH_LIBJPEG OFF CACHE STRING "not needed by MITIE" FORCE)
 set(DLIB_LINK_WITH_SQLITE3 OFF CACHE STRING "not needed by MITIE" FORCE)
 
-include(../../mitielib/tell_visual_studio_to_use_static_runtime.cmake)
 
 # Don't add mitie if it's already been added to the cmake project
 if (NOT TARGET mitie)
-
     # Determine the path to mitie.
     string(REPLACE "cmake" "" mitie_path ${CMAKE_CURRENT_LIST_FILE})
 
+    include(${mitie_path}/tell_visual_studio_to_use_static_runtime.cmake)
     include(${mitie_path}/../dlib/dlib/cmake)
 
     # Add folder containing mitie to the include search path.
@@ -23,4 +22,3 @@ if (NOT TARGET mitie)
 
     add_subdirectory(${mitie_path} mitie_build)
 endif()
-

--- a/mitielib/cmake
+++ b/mitielib/cmake
@@ -3,13 +3,13 @@ set(DLIB_LINK_WITH_LIBPNG OFF CACHE STRING "not needed by MITIE" FORCE)
 set(DLIB_LINK_WITH_LIBJPEG OFF CACHE STRING "not needed by MITIE" FORCE)
 set(DLIB_LINK_WITH_SQLITE3 OFF CACHE STRING "not needed by MITIE" FORCE)
 
+string(REPLACE "cmake" "" mitie_path ${CMAKE_CURRENT_LIST_FILE})
+
+include(${mitie_path}/tell_visual_studio_to_use_static_runtime.cmake)
 
 # Don't add mitie if it's already been added to the cmake project
 if (NOT TARGET mitie)
     # Determine the path to mitie.
-    string(REPLACE "cmake" "" mitie_path ${CMAKE_CURRENT_LIST_FILE})
-
-    include(${mitie_path}/tell_visual_studio_to_use_static_runtime.cmake)
     include(${mitie_path}/../dlib/dlib/cmake)
 
     # Add folder containing mitie to the include search path.


### PR DESCRIPTION
I've been trying to build the examples on Windows (8), but they don't appear to work when following the CMake instructions in the `readme.md` file, without updating this CMake file, to consistently point to the `MITIE/mitielib/tell_visual_studio_to_use_static_runtime.cmake` file. The relative path in place before (`../../mitielib/tell_visual_studio_to_use_static_runtime.cmake`), was breaking the CMake build step.