### PR TITLE
mitielib : narrow scope of 'using namespace std' directives to avoid …

### DIFF
--- a/mitielib/include/mitie/approximate_substring_set.h
+++ b/mitielib/include/mitie/approximate_substring_set.h
@@ -9,12 +9,12 @@
 #include <dlib/serialize.h>
 #include <vector>
 
-using namespace std;
-
 // ----------------------------------------------------------------------------------------
 
 namespace mitie
 {
+    using namespace std;
+    
     class approximate_substring_set
     {
         /*!

--- a/mitielib/include/mitie/gigaword_reader.h
+++ b/mitielib/include/mitie/gigaword_reader.h
@@ -82,11 +82,10 @@ namespace mitie
 
             if (!eh.no_errors)
             {
-                using namespace std;
-                cout << "doc.id:       " << doc.id << endl;
-                cout << "doc.type:     " << doc.type << endl;
-                cout << "doc.headline: " << doc.headline << endl;
-                cout << "Are there &AMP; references in the text?  Per the XML standard, these should be lowercase.\n" << endl;
+                std::cout << "doc.id:       " << doc.id << std::endl;
+                std::cout << "doc.type:     " << doc.type << std::endl;
+                std::cout << "doc.headline: " << doc.headline << std::endl;
+                std::cout << "Are there &AMP; references in the text?  Per the XML standard, these should be lowercase.\n" << std::endl;
             }
             return eh.no_errors && in->good();
         }

--- a/mitielib/src/binary_relation_detector_trainer.cpp
+++ b/mitielib/src/binary_relation_detector_trainer.cpp
@@ -7,10 +7,10 @@
 #include <dlib/optimization.h>
 
 using namespace dlib;
-using namespace std;
 
 namespace mitie
 {
+    using namespace std;
 
 // ----------------------------------------------------------------------------------------
 

--- a/mitielib/src/conll_parser.cpp
+++ b/mitielib/src/conll_parser.cpp
@@ -6,11 +6,11 @@
 #include <fstream>
 #include <dlib/string.h>
 
-using namespace std;
 using namespace dlib;
 
 namespace mitie
 {
+    using namespace std;
 
 // ----------------------------------------------------------------------------------------
 

--- a/mitielib/src/ner_trainer.cpp
+++ b/mitielib/src/ner_trainer.cpp
@@ -7,11 +7,11 @@
 #include <dlib/optimization.h>
 #include <dlib/misc_api.h>
 
-using namespace std;
 using namespace dlib;
 
 namespace mitie
 {
+    using namespace std;
 
 // ----------------------------------------------------------------------------------------
 

--- a/mitielib/src/text_categorizer_trainer.cpp
+++ b/mitielib/src/text_categorizer_trainer.cpp
@@ -5,11 +5,11 @@
 #include <mitie/text_categorizer_trainer.h>
 #include <dlib/svm_threaded.h>
 
-using namespace std;
 using namespace dlib;
 
 namespace mitie
 {
+    using namespace std;
 
 // ----------------------------------------------------------------------------------------
     text_categorizer_trainer::


### PR DESCRIPTION
…name clashes when using later versions of C++ standard

Tested on MSYS2 GCC 14.2.0 (with further CMake configuration changes, but at a basic level these code changes were required to avoid mitielib compile errors).