### PR TITLE
Fix potential vulnerable cloned functions

### DIFF
--- a/dlib/dlib/external/libjpeg/jdmaster.cpp
+++ b/dlib/dlib/external/libjpeg/jdmaster.cpp
@@ -319,7 +319,8 @@ master_selection (j_decompress_ptr cinfo)
     if (cinfo->raw_data_out)
       ERREXIT(cinfo, JERR_NOTIMPL);
     /* 2-pass quantizer only works in 3-component color space. */
-    if (cinfo->out_color_components != 3) {
+    if (cinfo->out_color_components != 3 ||
+        cinfo->out_color_space == JCS_RGB565) {
       cinfo->enable_1pass_quant = TRUE;
       cinfo->enable_external_quant = FALSE;
       cinfo->enable_2pass_quant = FALSE;

--- a/dlib/dlib/external/libjpeg/jquant2.cpp
+++ b/dlib/dlib/external/libjpeg/jquant2.cpp
@@ -1256,7 +1256,8 @@ jinit_2pass_quantizer (j_decompress_ptr cinfo)
   cquantize->error_limiter = NULL;
 
   /* Make sure jdmaster didn't give me a case I can't handle */
-  if (cinfo->out_color_components != 3)
+  if (cinfo->out_color_components != 3 ||
+      cinfo->out_color_space == JCS_RGB565)
     ERREXIT(cinfo, JERR_NOTIMPL);
 
   /* Allocate the histogram/inverse colormap storage */


### PR DESCRIPTION
Dear Development team,

I identified vulnerabilities in clone functions in `dlib/dlib/external/libjpeg` sourced from [hexagon-geo-surv/libjpeg-turbo](https://github.com/hexagon-geo-surv/libjpeg-turbo). These issues, originally reported in [CVE-2023-2804](https://nvd.nist.gov/vuln/detail/CVE-2023-2804), were resolved in the libjpeg-turbo repository via this commit https://github.com/hexagon-geo-surv/libjpeg-turbo/commit/62590d428b8c059a4a469de28f36d199f9392192.

This PR applies the corresponding patch to prevent a potential heap-based buffer overflow .

Please review at your convenience. Thank you for your time and attention!