### PR TITLE
fix: use angle brackets for includes under include/mitie

### DIFF
--- a/mitielib/include/mitie/count_min_sketch.h
+++ b/mitielib/include/mitie/count_min_sketch.h
@@ -4,12 +4,12 @@
 #ifndef MIT_LL_CoUNT_MIN_SKETCH_H_
 #define MIT_LL_CoUNT_MIN_SKETCH_H_
 
-#include "dlib/array2d.h"
-#include "dlib/uintn.h"
-#include "dlib/hash.h"
-#include "dlib/byte_orderer.h"
+#include <dlib/array2d.h>
+#include <dlib/uintn.h>
+#include <dlib/hash.h>
+#include <dlib/byte_orderer.h>
 #include <queue>
-#include "dlib/image_transforms.h"
+#include <dlib/image_transforms.h>
 
 namespace mitie
 {

--- a/mitielib/include/mitie/gigaword_reader.h
+++ b/mitielib/include/mitie/gigaword_reader.h
@@ -4,9 +4,9 @@
 #ifndef MIT_LL_GIGAWoRD_READER_H_
 #define MIT_LL_GIGAWoRD_READER_H_
 
-#include "dlib/xml_parser.h"
-#include "dlib/string.h"
-#include "dlib/dir_nav.h"
+#include <dlib/xml_parser.h>
+#include <dlib/string.h>
+#include <dlib/dir_nav.h>
 #include <list>
 #include <fstream>
 

--- a/mitielib/include/mitie/total_word_feature_extractor.h
+++ b/mitielib/include/mitie/total_word_feature_extractor.h
@@ -5,7 +5,7 @@
 #define MIT_LL_TOTAL_WoRD_FEATURE_EXTRACTOR_H_
 
 #include <map>
-#include "word_morphology_feature_extractor.h"
+#include <mitie/word_morphology_feature_extractor.h>
 #include <dlib/statistics.h>
 #include <dlib/vectorstream.h>
 #include <dlib/hash.h>

--- a/mitielib/include/mitie/word_morphology_feature_extractor.h
+++ b/mitielib/include/mitie/word_morphology_feature_extractor.h
@@ -4,7 +4,7 @@
 #ifndef MIT_LL_WORD_MORPHOLOGY_FEATURE_ExTRACTOR_H_
 #define MIT_LL_WORD_MORPHOLOGY_FEATURE_ExTRACTOR_H_
 
-#include "approximate_substring_set.h"
+#include <mitie/approximate_substring_set.h>
 #include <dlib/matrix.h>
 
 namespace mitie


### PR DESCRIPTION
Makes include style and resolution behaviour consistent across include/mitie. Angle brackets are already the main convention.